### PR TITLE
refactor: improve README & tweak issues level

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,11 @@ sherif -p @repo/tools
 > **Note**
 > Sherif doesn't have many rules for now, but will likely have more in the future (along with more features).
 
-#### ⨯ `empty-dependencies`
+#### `empty-dependencies` ❌
 
 `package.json` files should not have empty dependencies fields.
 
-#### ⨯ `multiple-dependency-versions`
+#### `multiple-dependency-versions` ❌
 
 A given dependency should use the same version across the monorepo.
 
@@ -90,19 +90,19 @@ You can ignore this rule for a dependency if you expect to have multiple version
 sherif -i react -i @types/node
 ```
 
-#### ⚠️ `packages-without-package-json`
+#### `packages-without-package-json` ⚠️
 
 All packages defined in the root `package.json`' `workspaces` field or `pnpm-workspace.yaml` should have a `package.json` file.
 
-#### ⚠️ `root-package-dependencies`
+#### `root-package-dependencies` ⚠️
 
 The root `package.json` is private, so making a distinction between `dependencies` and `devDependencies` is useless - only use `devDependencies`.
 
-#### ⨯ `root-package-manager-field`
+#### `root-package-manager-field` ❌
 
 The root `package.json` should specify the package manager and version to use. Useful for tools like corepack.
 
-#### ⨯ `root-package-private-field`
+#### `root-package-private-field` ❌
 
 The root `package.json` should be private to prevent accidentaly publishing it to a registry.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Sherif is an opinionated, zero-config linter for JavaScript monorepos. It runs f
 
 ## Installation
 
-Run `sherif` in the root of your monorepo to list the found issues:
+Run `sherif` in the root of your monorepo to list the found issues. Any error will cause Sherif to exit with a code 1:
 
 ```bash
 # PNPM
@@ -31,40 +31,80 @@ pnpm dlx sherif@latest
 npx sherif@latest
 ```
 
-Any error will cause Sherif to exit with a code 1. We recommend running Sherif in your CI once all errors are fixed. This is useful to prevent regressions (e.g. when adding a library to a package but forgetting to update the version in other packages of the monorepo)
+We recommend running Sherif in your CI once all errors are fixed. Run it by **specifying a version instead of latest**. This is useful to prevent regressions (e.g. when adding a library to a package but forgetting to update the version in other packages of the monorepo).
+
+<details>
+
+<summary>GitHub Actions example</summary>
+
+```
+name: Sherif
+on:
+  pull_request:
+jobs:
+  check:
+    name: Run Sherif
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - run: npx sherif@0.1.0
+```
+
+</details>
 
 ## Rules
 
-You can use `--ignore-rule <name>` (or `-r <name>`) to ignore one or multiple rules, and `--ignore-package <name>` (or `-p <name>`) to ignore one or multiple packages.
+You can ignore a specific rule by using `--ignore-rule <name>` (or `-r <name>`):
+
+```bash
+# Ignore both rules
+sherif -r packages-without-package-json -r root-package-manager-field
+```
+
+You can ignore all issues in a package by using `--ignore-package <name>` (or `-p <name>`):
+
+```bash
+# Ignore all issues in the package
+sherif -p @repo/tools
+```
 
 > **Note**
 > Sherif doesn't have many rules for now, but will likely have more in the future (along with more features).
 
 #### `empty-dependencies`
 
-`package.json` files should not have empty dependencies fields.
+⨯ Error: `package.json` files should not have empty dependencies fields.
 
 #### `multiple-dependency-versions`
 
-A given dependency should use the same version across the monorepo.
+⨯ Error: A given dependency should use the same version across the monorepo.
 
-You can use `--ignore-dependency <name>` (or `-i <name>`) to ignore a dependency and allow having multiple versions of it.
+You can ignore this rule for a dependency if you expect to have multiple versions by using `--ignore-dependency <name>` (or `-i <name>`):
+
+```bash
+# Ignore dependencies that are expected to have multiple versions
+sherif -i react -i @types/node
+```
 
 #### `packages-without-package-json`
 
-All packages defined in the root `package.json`' `workspaces` field or `pnpm-workspace.yaml` should have a `package.json` file.
+⚠️ Warning: All packages defined in the root `package.json`' `workspaces` field or `pnpm-workspace.yaml` should have a `package.json` file.
 
 #### `root-package-dependencies`
 
-The root `package.json` is private, so making a distinction between `dependencies` and `devDependencies` is useless - only use `devDependencies`.
+⨯ Warning: The root `package.json` is private, so making a distinction between `dependencies` and `devDependencies` is useless - only use `devDependencies`.
 
 #### `root-package-manager-field`
 
-The root `package.json` should specify the package manager and version to use. Useful for tools like corepack.
+⨯ Error: The root `package.json` should specify the package manager and version to use. Useful for tools like corepack.
 
 #### `root-package-private-field`
 
-The root `package.json` should be private to prevent accidentaly publishing it to a registry.
+⨯ Error: The root `package.json` should be private to prevent accidentaly publishing it to a registry.
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ We recommend running Sherif in your CI once all errors are fixed. Run it by **sp
 
 <summary>GitHub Actions example</summary>
 
-```
+```yaml
 name: Sherif
 on:
   pull_request:
@@ -75,13 +75,13 @@ sherif -p @repo/tools
 > **Note**
 > Sherif doesn't have many rules for now, but will likely have more in the future (along with more features).
 
-#### `empty-dependencies`
+#### ⨯ `empty-dependencies`
 
-⨯ Error: `package.json` files should not have empty dependencies fields.
+`package.json` files should not have empty dependencies fields.
 
-#### `multiple-dependency-versions`
+#### ⨯ `multiple-dependency-versions`
 
-⨯ Error: A given dependency should use the same version across the monorepo.
+A given dependency should use the same version across the monorepo.
 
 You can ignore this rule for a dependency if you expect to have multiple versions by using `--ignore-dependency <name>` (or `-i <name>`):
 
@@ -90,21 +90,21 @@ You can ignore this rule for a dependency if you expect to have multiple version
 sherif -i react -i @types/node
 ```
 
-#### `packages-without-package-json`
+#### ⚠️ `packages-without-package-json`
 
-⚠️ Warning: All packages defined in the root `package.json`' `workspaces` field or `pnpm-workspace.yaml` should have a `package.json` file.
+All packages defined in the root `package.json`' `workspaces` field or `pnpm-workspace.yaml` should have a `package.json` file.
 
-#### `root-package-dependencies`
+#### ⚠️ `root-package-dependencies`
 
-⨯ Warning: The root `package.json` is private, so making a distinction between `dependencies` and `devDependencies` is useless - only use `devDependencies`.
+The root `package.json` is private, so making a distinction between `dependencies` and `devDependencies` is useless - only use `devDependencies`.
 
-#### `root-package-manager-field`
+#### ⨯ `root-package-manager-field`
 
-⨯ Error: The root `package.json` should specify the package manager and version to use. Useful for tools like corepack.
+The root `package.json` should specify the package manager and version to use. Useful for tools like corepack.
 
-#### `root-package-private-field`
+#### ⨯ `root-package-private-field`
 
-⨯ Error: The root `package.json` should be private to prevent accidentaly publishing it to a registry.
+The root `package.json` should be private to prevent accidentaly publishing it to a registry.
 
 ## Credits
 

--- a/fixtures/dependencies-star/docs/package.json
+++ b/fixtures/dependencies-star/docs/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "docs",
+  "dependencies": {
+    "next": "1.2.3",
+    "eslint": "7.8.9",
+    "react": "*"
+  }
+}

--- a/fixtures/dependencies-star/package.json
+++ b/fixtures/dependencies-star/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "dependencies-star",
+  "workspaces": [
+    "packages/*",
+    "docs"
+  ],
+  "private": true,
+  "packageManager": "pnpm@1.2.3",
+  "devDependencies": {
+    "eslint": "1.2.3",
+    "prettier": "1.2.3"
+  }
+}

--- a/fixtures/dependencies-star/packages/abc/package.json
+++ b/fixtures/dependencies-star/packages/abc/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "abc",
+  "dependencies": {
+    "next": "4.5.6",
+    "react": "1.2.3"
+  }
+}

--- a/fixtures/dependencies-star/packages/def/package.json
+++ b/fixtures/dependencies-star/packages/def/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "def",
+  "dependencies": {
+    "next": "1.2.3",
+    "react": "1.2.3"
+  }
+}

--- a/src/collect.rs
+++ b/src/collect.rs
@@ -131,7 +131,7 @@ pub fn collect_issues(args: &Args, packages_list: PackagesList) -> IssuesList<'_
             }
 
             for (name, version) in dependencies {
-                if version.comparators.len() != 0 {
+                if !version.comparators.is_empty() {
                     all_dependencies
                         .entry(name)
                         .or_insert_with(Vec::new)

--- a/src/rules/empty_dependencies.rs
+++ b/src/rules/empty_dependencies.rs
@@ -42,7 +42,7 @@ impl Issue for EmptyDependenciesIssue {
     }
 
     fn level(&self) -> IssueLevel {
-        IssueLevel::Warning
+        IssueLevel::Error
     }
 
     fn message(&self) -> String {
@@ -67,7 +67,7 @@ mod test {
         let issue = EmptyDependenciesIssue::new("test".to_string(), DependencyKind::Dependencies);
 
         assert_eq!(issue.name(), "empty-dependencies");
-        assert_eq!(issue.level(), IssueLevel::Warning);
+        assert_eq!(issue.level(), IssueLevel::Error);
     }
 
     #[test]

--- a/src/rules/packages_without_package_json.rs
+++ b/src/rules/packages_without_package_json.rs
@@ -46,3 +46,42 @@ impl Issue for PackagesWithoutPackageJsonIssue {
         Some(self)
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test() {
+        let issue = PackagesWithoutPackageJsonIssue::new();
+
+        assert_eq!(issue.name(), "packages-without-package-json");
+        assert_eq!(issue.level(), IssueLevel::Warning);
+    }
+
+    #[test]
+    fn single_package() {
+        let mut issue = PackagesWithoutPackageJsonIssue::new();
+        issue.add_package("test".to_string());
+
+        colored::control::set_override(false);
+        assert_eq!(
+            issue.message(),
+            "1 package doesn't have a package.json file: test"
+        );
+    }
+
+    #[test]
+    fn multiple_packages() {
+        let mut issue = PackagesWithoutPackageJsonIssue::new();
+        issue.add_package("test".to_string());
+        issue.add_package("test-2".to_string());
+        issue.add_package("test-3".to_string());
+
+        colored::control::set_override(false);
+        assert_eq!(
+            issue.message(),
+            "3 packages doesn't have a package.json file: test, test-2, test-3"
+        );
+    }
+}

--- a/src/rules/root_package_dependencies.rs
+++ b/src/rules/root_package_dependencies.rs
@@ -22,7 +22,7 @@ impl Issue for RootPackageDependenciesIssue {
 
     fn message(&self) -> String {
         format!(
-            "./package.json shouldn't have any `{}` , only `{}`",
+            "./package.json shouldn't have any `{}` , only `{}`.",
             "dependencies".red(),
             "devDependencies".green()
         )
@@ -47,7 +47,7 @@ mod test {
         colored::control::set_override(false);
         assert_eq!(
             issue.message(),
-            "./package.json shouldn't have any `dependencies` , only `devDependencies`"
+            "./package.json shouldn't have any `dependencies` , only `devDependencies`."
         );
     }
 }


### PR DESCRIPTION
- Improve README with more examples 
- `empty-dependencies` is now an error
- Ignore dependencies versions that are `*`, since they match any other defined version in the monorepo