### PR TITLE
feat: add types in dependencies rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ The root `package.json` should specify the package manager and version to use. U
 
 The root `package.json` should be private to prevent accidentaly publishing it to a registry.
 
+#### `types-in-dependencies` ❌
+
+Private packages shouldn't have `@types/*` in `dependencies`, since they don't need it at runtime. Move them to `devDependencies`.
+
 ## Credits
 
 - [dedubcheck](https://github.com/innovatrics/dedubcheck) that given me the idea for Sherif

--- a/src/packages/mod.rs
+++ b/src/packages/mod.rs
@@ -65,6 +65,14 @@ impl Package {
         &self.inner.name
     }
 
+    pub fn get_path(&self) -> String {
+        self.path.to_string_lossy().to_string()
+    }
+
+    pub fn is_private(&self) -> bool {
+        self.inner.private.unwrap_or(false)
+    }
+
     fn check_deps(
         &self,
         deps: &Option<IndexMap<String, String>>,
@@ -73,7 +81,7 @@ impl Package {
         if let Some(dependencies) = deps {
             if dependencies.is_empty() {
                 return Some(EmptyDependenciesIssue::new(
-                    self.path.to_string_lossy().to_string(),
+                    self.get_path(),
                     dependency_kind,
                 ));
             }

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -7,6 +7,7 @@ pub mod packages_without_package_json;
 pub mod root_package_dependencies;
 pub mod root_package_manager_field;
 pub mod root_package_private_field;
+pub mod types_in_dependencies;
 
 pub const ERROR: &str = "⨯";
 pub const WARNING: &str = "⚠️";

--- a/src/rules/types_in_dependencies.rs
+++ b/src/rules/types_in_dependencies.rs
@@ -41,3 +41,29 @@ impl Issue for TypesInDependenciesIssue {
         ))
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test() {
+        let issue = TypesInDependenciesIssue::new(
+            "test".into(),
+            vec!["@types/react".into(), "@types/react-dom".into()],
+        );
+
+        assert_eq!(issue.name(), "types-in-dependencies");
+        assert_eq!(issue.level(), IssueLevel::Error);
+
+        colored::control::set_override(false);
+        assert_eq!(
+            issue.message(),
+            "test/package.json is private but has `@types/*` dependencies in `dependencies` instead of `devDependencies`."
+        );
+        assert_eq!(
+            issue.why(),
+            "Private packages shouldn't have `@types/*` in `dependencies`: @types/react, @types/react-dom"
+        );
+    }
+}

--- a/src/rules/types_in_dependencies.rs
+++ b/src/rules/types_in_dependencies.rs
@@ -1,0 +1,43 @@
+use colored::Colorize;
+
+use super::{Issue, IssueLevel};
+use std::borrow::Cow;
+
+#[derive(Debug)]
+pub struct TypesInDependenciesIssue {
+    package: String,
+    packages: Vec<String>,
+}
+
+impl TypesInDependenciesIssue {
+    pub fn new(package: String, packages: Vec<String>) -> Box<Self> {
+        Box::new(Self { package, packages })
+    }
+}
+
+impl Issue for TypesInDependenciesIssue {
+    fn name(&self) -> &str {
+        "types-in-dependencies"
+    }
+
+    fn level(&self) -> IssueLevel {
+        IssueLevel::Error
+    }
+
+    fn message(&self) -> String {
+        format!(
+            "{}/package.json is private but has `{}` dependencies in `{}` instead of `{}`.",
+            self.package,
+            "@types/*".blue(),
+            "dependencies".red(),
+            "devDependencies".green(),
+        )
+    }
+
+    fn why(&self) -> Cow<'static, str> {
+        Cow::Owned(format!(
+            "Private packages shouldn't have `@types/*` in `dependencies`: {}",
+            self.packages.join(", ")
+        ))
+    }
+}


### PR DESCRIPTION
Closes https://github.com/QuiiBz/sherif/issues/8

Private packages shouldn't have `@types/*` in `dependencies`, since they don't need it at runtime. Move them to `devDependencies`.