### PR TITLE
feat: autofix `empty-dependencies`

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -7,6 +7,10 @@ pub struct Args {
     #[arg(default_value = ".")]
     pub path: PathBuf,
 
+    /// Fix the issues automatically, if possible.
+    #[arg(long)]
+    pub fix: bool,
+
     /// Ignore the `multiple-dependency-versions` rule for the given dependency name.
     #[arg(long, short)]
     pub ignore_dependency: Vec<String>,

--- a/src/collect.rs
+++ b/src/collect.rs
@@ -186,6 +186,7 @@ mod test {
     fn collect_packages_unknown_dir() {
         let args = Args {
             path: "unknown".into(),
+            fix: false,
             ignore_rule: Vec::new(),
             ignore_package: Vec::new(),
             ignore_dependency: Vec::new(),
@@ -204,6 +205,7 @@ mod test {
     fn collect_packages_empty_dir() {
         let args = Args {
             path: "fixtures/empty".into(),
+            fix: false,
             ignore_rule: Vec::new(),
             ignore_package: Vec::new(),
             ignore_dependency: Vec::new(),
@@ -222,6 +224,7 @@ mod test {
     fn collect_packages_basic() {
         let args = Args {
             path: "fixtures/basic".into(),
+            fix: false,
             ignore_rule: Vec::new(),
             ignore_package: Vec::new(),
             ignore_dependency: Vec::new(),
@@ -245,6 +248,7 @@ mod test {
     fn collect_packages_pnpm() {
         let args = Args {
             path: "fixtures/pnpm".into(),
+            fix: false,
             ignore_rule: Vec::new(),
             ignore_package: Vec::new(),
             ignore_dependency: Vec::new(),
@@ -268,6 +272,7 @@ mod test {
     fn collect_packages_no_workspace_pnpm() {
         let args = Args {
             path: "fixtures/no-workspace-pnpm".into(),
+            fix: false,
             ignore_rule: Vec::new(),
             ignore_package: Vec::new(),
             ignore_dependency: Vec::new(),
@@ -286,6 +291,7 @@ mod test {
     fn collect_packages_without_package_json() {
         let args = Args {
             path: "fixtures/without-package-json".into(),
+            fix: false,
             ignore_rule: Vec::new(),
             ignore_package: Vec::new(),
             ignore_dependency: Vec::new(),
@@ -311,6 +317,7 @@ mod test {
     fn collect_root_issues() {
         let args = Args {
             path: "fixtures/root-issues".into(),
+            fix: false,
             ignore_rule: Vec::new(),
             ignore_package: Vec::new(),
             ignore_dependency: Vec::new(),
@@ -344,6 +351,7 @@ mod test {
     #[test]
     fn collect_root_issues_fixed() {
         let args = Args {
+            fix: false,
             path: "fixtures/root-issues-fixed".into(),
             ignore_rule: Vec::new(),
             ignore_package: Vec::new(),
@@ -361,6 +369,7 @@ mod test {
     fn collect_dependencies() {
         let args = Args {
             path: "fixtures/dependencies".into(),
+            fix: false,
             ignore_rule: Vec::new(),
             ignore_package: Vec::new(),
             ignore_dependency: Vec::new(),
@@ -388,6 +397,7 @@ mod test {
     fn collect_dependencies_without_star() {
         let args = Args {
             path: "fixtures/dependencies-star".into(),
+            fix: false,
             ignore_rule: Vec::new(),
             ignore_package: Vec::new(),
             ignore_dependency: Vec::new(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,12 @@ fn main() {
     let issues = collect_issues(&args, packages_list);
 
     if args.fix {
-        issues.fix();
+        if let Err(error) = issues.fix() {
+            eprintln!();
+            eprintln!(" {} {}", IssueLevel::Error, "Failed to fix issues".bold());
+            eprintln!("   {}", error.to_string().bright_black());
+            std::process::exit(1);
+        }
     }
 
     let total_issues = issues.total_len();

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,11 @@ fn main() {
 
     let total_packages = packages_list.packages.len();
     let issues = collect_issues(&args, packages_list);
+
+    if args.fix {
+        issues.fix();
+    }
+
     let total_issues = issues.total_len();
 
     if total_issues == 0 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ fn main() {
     };
 
     let total_packages = packages_list.packages.len();
-    let issues = collect_issues(&args, packages_list);
+    let mut issues = collect_issues(&args, packages_list);
 
     if args.fix {
         if let Err(error) = issues.fix() {
@@ -52,6 +52,7 @@ fn main() {
 
     let warnings = issues.len_by_level(IssueLevel::Warning);
     let errors = issues.len_by_level(IssueLevel::Error);
+    let fixed = issues.len_by_level(IssueLevel::Fixed);
 
     if let Err(error) = print_issues(issues) {
         eprintln!();
@@ -60,7 +61,7 @@ fn main() {
         std::process::exit(1);
     }
 
-    print_footer(total_issues, total_packages, warnings, errors, now);
+    print_footer(total_issues, total_packages, warnings, errors, fixed, now);
 
     if errors > 0 {
         std::process::exit(1);

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -48,13 +48,18 @@ pub fn print_footer(
     total_packages: usize,
     warnings: usize,
     errors: usize,
+    fixed: usize,
     start: Instant,
 ) {
     println!();
     println!(
         "{} found {} across {} in {:?}.",
         "issue".plural(total_issues),
-        format!("({} {}, {} {})", errors, ERROR, warnings, WARNING,).bright_black(),
+        format!(
+            "({} {}, {} {}, {} {})",
+            errors, ERROR, warnings, WARNING, fixed, SUCCESS
+        )
+        .bright_black(),
         "package".plural(total_packages),
         start.elapsed(),
     );

--- a/src/rules/empty_dependencies.rs
+++ b/src/rules/empty_dependencies.rs
@@ -58,6 +58,11 @@ impl Issue for EmptyDependenciesIssue {
     fn why(&self) -> Cow<'static, str> {
         Cow::Borrowed("package.json should not have empty dependencies fields.")
     }
+
+    fn fix(&self) -> bool {
+        // TODO: read & remove self.dependency_kind from root package.json
+        false
+    }
 }
 
 #[cfg(test)]

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -1,3 +1,4 @@
+use anyhow::{anyhow, Result};
 use colored::Colorize;
 use indexmap::IndexMap;
 use std::{borrow::Cow, fmt::Display};
@@ -46,8 +47,8 @@ pub trait Issue {
     fn message(&self) -> String;
     fn why(&self) -> Cow<'static, str>;
 
-    fn fix(&self) -> bool {
-        false
+    fn fix(&self, _package_type: &PackageType) -> Result<bool> {
+        Ok(false)
     }
 }
 
@@ -109,12 +110,16 @@ impl<'a> IssuesList<'a> {
             .count()
     }
 
-    pub fn fix(&self) {
-        for issues in self.issues.values() {
+    pub fn fix(&self) -> Result<()> {
+        for (package_type, issues) in &self.issues {
             for issue in issues {
-                issue.fix();
+                if let Err(error) = issue.fix(package_type) {
+                    return Err(anyhow!("Error while fixing {}: {}", package_type, error));
+                }
             }
         }
+
+        Ok(())
     }
 }
 

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -45,6 +45,10 @@ pub trait Issue {
     fn level(&self) -> IssueLevel;
     fn message(&self) -> String;
     fn why(&self) -> Cow<'static, str>;
+
+    fn fix(&self) -> bool {
+        false
+    }
 }
 
 pub type BoxIssue = Box<dyn Issue>;
@@ -103,6 +107,14 @@ impl<'a> IssuesList<'a> {
             .flatten()
             .filter(|issue| issue.level() == level)
             .count()
+    }
+
+    pub fn fix(&self) {
+        for issues in self.issues.values() {
+            for issue in issues {
+                issue.fix();
+            }
+        }
     }
 }
 

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -19,6 +19,7 @@ pub const SUCCESS: &str = "✓";
 pub enum IssueLevel {
     Error,
     Warning,
+    Fixed,
 }
 
 impl IssueLevel {
@@ -26,6 +27,7 @@ impl IssueLevel {
         match self {
             IssueLevel::Error => "⨯ error",
             IssueLevel::Warning => "⚠️ warning",
+            IssueLevel::Fixed => "✓ fixed",
         }
     }
 }
@@ -37,6 +39,7 @@ impl Display for IssueLevel {
         match self {
             IssueLevel::Error => write!(f, "{}", value.red()),
             IssueLevel::Warning => write!(f, "{}", value.yellow()),
+            IssueLevel::Fixed => write!(f, "{}", value.green()),
         }
     }
 }
@@ -47,8 +50,8 @@ pub trait Issue {
     fn message(&self) -> String;
     fn why(&self) -> Cow<'static, str>;
 
-    fn fix(&self, _package_type: &PackageType) -> Result<bool> {
-        Ok(false)
+    fn fix(&mut self, _package_type: &PackageType) -> Result<()> {
+        Ok(())
     }
 }
 
@@ -110,8 +113,8 @@ impl<'a> IssuesList<'a> {
             .count()
     }
 
-    pub fn fix(&self) -> Result<()> {
-        for (package_type, issues) in &self.issues {
+    pub fn fix(&mut self) -> Result<()> {
+        for (package_type, issues) in self.issues.iter_mut() {
             for issue in issues {
                 if let Err(error) = issue.fix(package_type) {
                     return Err(anyhow!("Error while fixing {}: {}", package_type, error));


### PR DESCRIPTION
Closes #6 

Add a new `--fix` option to autofix issues when possible.