### PR TITLE
fix(multiple-dependency-versions): increase versions padding

### DIFF
--- a/src/rules/multiple_dependency_versions.rs
+++ b/src/rules/multiple_dependency_versions.rs
@@ -74,7 +74,7 @@ impl Issue for MultipleDependencyVersionsIssue {
                     (version.to_string().yellow(), "∼ between".yellow())
                 };
 
-                let version_pad = " ".repeat(if end.len() > 16 { 3 } else { 16 - end.len() });
+                let version_pad = " ".repeat(if end.len() > 26 { 3 } else { 26 - end.len() });
 
                 if group.is_empty() || group != common_path {
                     let root = common_path.join("/").bright_black();

--- a/src/rules/snapshots/sherif__rules__multiple_dependency_versions__test__dedupe.snap
+++ b/src/rules/snapshots/sherif__rules__multiple_dependency_versions__test__dedupe.snap
@@ -3,7 +3,7 @@ source: src/rules/multiple_dependency_versions.rs
 expression: issue.message()
 ---
   
-      package-a       ^1.2.3   ↓ lowest
+      package-a                 ^1.2.3   ↓ lowest
   packages
-      package-b       ^3.1.6   ↑ highest
-      package-c       ^3.1.6   ↑ highest
+      package-b                 ^3.1.6   ↑ highest
+      package-c                 ^3.1.6   ↑ highest

--- a/src/rules/snapshots/sherif__rules__multiple_dependency_versions__test__order_multiple.snap
+++ b/src/rules/snapshots/sherif__rules__multiple_dependency_versions__test__order_multiple.snap
@@ -3,8 +3,8 @@ source: src/rules/multiple_dependency_versions.rs
 expression: issue.message()
 ---
   apps
-      package-b       ^1.2.3   ↓ lowest
+      package-b                 ^1.2.3   ↓ lowest
   packages
-      package-c       ^3.1.6   ∼ between
+      package-c                 ^3.1.6   ∼ between
   apps
-      package-a       ^5.6.3   ↑ highest
+      package-a                 ^5.6.3   ↑ highest

--- a/src/rules/snapshots/sherif__rules__multiple_dependency_versions__test__order_single.snap
+++ b/src/rules/snapshots/sherif__rules__multiple_dependency_versions__test__order_single.snap
@@ -3,4 +3,4 @@ source: src/rules/multiple_dependency_versions.rs
 expression: issue.message()
 ---
   
-      package-a       ^1.2.3   ↑ highest
+      package-a                 ^1.2.3   ↑ highest


### PR DESCRIPTION
Increase versions padding for the `multiple-dependency-versions` rule to make it more aligned. Example with the tanstack query repo:

| Before | After |
|--------|--------|
| <img width="1235" alt="Screenshot 2023-11-11 at 08 46 30" src="https://github.com/QuiiBz/sherif/assets/43268759/6efdceb7-ab95-4bc7-9f19-515732adafd5"> | <img width="1212" alt="Screenshot 2023-11-11 at 09 01 37" src="https://github.com/QuiiBz/sherif/assets/43268759/8e401ca5-52ae-4250-993f-c5b0b2607a0d"> | 