### PR TITLE
feat: new `non-existant-packages` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,13 @@ You can ignore this rule for a dependency if you expect to have multiple version
 sherif -i react -i @types/node
 ```
 
+#### `non-existant-packages` ⚠️
+
+All paths defined in the workspace (the root `package.json`' `workspaces` field or `pnpm-workspace.yaml`) should match at least one package.
+
 #### `packages-without-package-json` ⚠️
 
-All packages defined in the root `package.json`' `workspaces` field or `pnpm-workspace.yaml` should have a `package.json` file.
+All packages matching the workspace (the root `package.json`' `workspaces` field or `pnpm-workspace.yaml`) should have a `package.json` file.
 
 #### `root-package-dependencies` ⚠️
 

--- a/fixtures/basic/package.json
+++ b/fixtures/basic/package.json
@@ -2,6 +2,8 @@
   "name": "basic",
   "workspaces": [
     "packages/*",
-    "docs"
+    "docs",
+    "examples/*",
+    "website"
   ]
 }

--- a/fixtures/pnpm/pnpm-workspace.yaml
+++ b/fixtures/pnpm/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
 packages:
   - 'packages/*'
   - 'docs'
+  - 'examples/*'
+  - 'website'

--- a/src/collect.rs
+++ b/src/collect.rs
@@ -303,7 +303,8 @@ mod test {
 
         assert_eq!(root_package.get_name(), "basic");
         assert_eq!(packages.len(), 3);
-        assert_eq!(packages_issues.len(), 0);
+        assert_eq!(packages_issues.len(), 1);
+        assert!(packages_issues[0].name() == "non-existant-packages");
     }
 
     #[test]
@@ -327,7 +328,8 @@ mod test {
 
         assert_eq!(root_package.get_name(), "pnpm");
         assert_eq!(packages.len(), 3);
-        assert_eq!(packages_issues.len(), 0);
+        assert_eq!(packages_issues.len(), 1);
+        assert!(packages_issues[0].name() == "non-existant-packages");
     }
 
     #[test]

--- a/src/collect.rs
+++ b/src/collect.rs
@@ -127,7 +127,7 @@ pub fn collect_packages(args: &Args) -> Result<PackagesList> {
             }
         }
 
-        if non_existant_paths.len() > 0 {
+        if !non_existant_paths.is_empty() {
             packages_issues.push(NonExistantPackagesIssue::new(
                 is_pnpm_workspace,
                 packages_list.unwrap(),

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -5,6 +5,7 @@ use std::{borrow::Cow, fmt::Display};
 
 pub mod empty_dependencies;
 pub mod multiple_dependency_versions;
+pub mod non_existant_packages;
 pub mod packages_without_package_json;
 pub mod root_package_dependencies;
 pub mod root_package_manager_field;

--- a/src/rules/non_existant_packages.rs
+++ b/src/rules/non_existant_packages.rs
@@ -91,7 +91,7 @@ impl Issue for NonExistantPackagesIssue {
     }
 
     fn why(&self) -> Cow<'static, str> {
-        Cow::Borrowed("All paths in the workspace should have at least one package.")
+        Cow::Borrowed("All paths defined in the workspace should match at least one package.")
     }
 }
 
@@ -116,7 +116,7 @@ mod test {
         assert_eq!(issue.level(), IssueLevel::Warning);
         assert_eq!(
             issue.why(),
-            "All paths in the workspace should have at least one package."
+            "All paths defined in the workspace should match at least one package."
         );
     }
 

--- a/src/rules/non_existant_packages.rs
+++ b/src/rules/non_existant_packages.rs
@@ -1,0 +1,156 @@
+use super::{Issue, IssueLevel};
+use colored::Colorize;
+use std::borrow::Cow;
+
+#[derive(Debug)]
+pub struct NonExistantPackagesIssue {
+    pnpm_workspace: bool,
+    packages_list: Vec<String>,
+    paths: Vec<String>,
+}
+
+impl NonExistantPackagesIssue {
+    pub fn new(pnpm_workspace: bool, packages_list: Vec<String>, paths: Vec<String>) -> Box<Self> {
+        Box::new(Self {
+            pnpm_workspace,
+            packages_list,
+            paths,
+        })
+    }
+
+    fn pnpm_message(&self) -> String {
+        let workspaces = self
+            .packages_list
+            .iter()
+            .map(|package| match self.paths.contains(package) {
+                true => format!(
+                    "  {}  - '{}'   {}",
+                    "-".red(),
+                    package.white(),
+                    "← but this one doesn't match any package".red(),
+                ),
+                false => format!("  │  - '{}'", package),
+            })
+            .collect::<Vec<String>>()
+            .join("\n");
+
+        format!(
+            r#"  │ packages:   {}
+{}"#,
+            "← Workspace has paths defined...".blue(),
+            workspaces,
+        )
+        .bright_black()
+        .to_string()
+    }
+
+    fn package_message(&self) -> String {
+        let workspaces = self
+            .packages_list
+            .iter()
+            .map(|package| match self.paths.contains(package) {
+                true => format!(
+                    r#"  {}     "{}",   {}"#,
+                    "-".red(),
+                    package.white(),
+                    "← but this one doesn't match any package".red(),
+                ),
+                false => format!(r#"  │     "{}","#, package),
+            })
+            .collect::<Vec<String>>()
+            .join("\n");
+
+        format!(
+            r#"  │ {{
+  │   "workspaces": [   {}
+{}
+  │   ],
+  │ }}"#,
+            "← Workspace has paths defined...".blue(),
+            workspaces,
+        )
+        .bright_black()
+        .to_string()
+    }
+}
+
+impl Issue for NonExistantPackagesIssue {
+    fn name(&self) -> &str {
+        "non-existant-packages"
+    }
+
+    fn level(&self) -> IssueLevel {
+        IssueLevel::Warning
+    }
+
+    fn message(&self) -> String {
+        match self.pnpm_workspace {
+            true => self.pnpm_message(),
+            false => self.package_message(),
+        }
+    }
+
+    fn why(&self) -> Cow<'static, str> {
+        Cow::Borrowed("All paths in the workspace should have at least one package.")
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test() {
+        let issue = NonExistantPackagesIssue::new(
+            true,
+            vec![
+                "apps/*".into(),
+                "packages/*".into(),
+                "empty/*".into(),
+                "docs".into(),
+            ],
+            vec!["empty/*".into(), "docs".into()],
+        );
+
+        assert_eq!(issue.name(), "non-existant-packages");
+        assert_eq!(issue.level(), IssueLevel::Warning);
+        assert_eq!(
+            issue.why(),
+            "All paths in the workspace should have at least one package."
+        );
+    }
+
+    #[test]
+    fn test_pnpm_workspace() {
+        let issue = NonExistantPackagesIssue::new(
+            true,
+            vec![
+                "apps/*".into(),
+                "packages/*".into(),
+                "empty/*".into(),
+                "docs".into(),
+            ],
+            vec!["empty/*".into(), "docs".into()],
+        );
+
+        colored::control::set_override(false);
+        insta::assert_snapshot!(issue.message());
+    }
+
+    #[test]
+    fn test_package_workspace() {
+        let issue = NonExistantPackagesIssue::new(
+            false,
+            vec![
+                "apps/*".into(),
+                "packages/*".into(),
+                "empty/*".into(),
+                "docs".into(),
+            ],
+            vec!["empty/*".into(), "docs".into()],
+        );
+
+        colored::control::set_override(false);
+        insta::assert_snapshot!(issue.message());
+    }
+}

--- a/src/rules/packages_without_package_json.rs
+++ b/src/rules/packages_without_package_json.rs
@@ -26,7 +26,7 @@ impl Issue for PackagesWithoutPackageJsonIssue {
     }
 
     fn why(&self) -> Cow<'static, str> {
-        Cow::Borrowed("All packages in the workspace should have a package.json file.")
+        Cow::Borrowed("All packages matching the workspace should have a package.json file.")
     }
 }
 
@@ -45,7 +45,7 @@ mod test {
         assert_eq!(issue.message(), "   test/package.json doesn't exists.");
         assert_eq!(
             issue.why(),
-            "All packages in the workspace should have a package.json file."
+            "All packages matching the workspace should have a package.json file."
         );
     }
 }

--- a/src/rules/snapshots/sherif__rules__non_existant_packages__test__package_workspace.snap
+++ b/src/rules/snapshots/sherif__rules__non_existant_packages__test__package_workspace.snap
@@ -1,0 +1,12 @@
+---
+source: src/rules/non_existant_packages.rs
+expression: issue.message()
+---
+  │ {
+  │   "workspaces": [   ← Workspace has paths defined...
+  │     "apps/*",
+  │     "packages/*",
+  -     "empty/*",   ← but this one doesn't match any package
+  -     "docs",   ← but this one doesn't match any package
+  │   ],
+  │ }

--- a/src/rules/snapshots/sherif__rules__non_existant_packages__test__pnpm_workspace.snap
+++ b/src/rules/snapshots/sherif__rules__non_existant_packages__test__pnpm_workspace.snap
@@ -1,0 +1,9 @@
+---
+source: src/rules/non_existant_packages.rs
+expression: issue.message()
+---
+  │ packages:   ← Workspace has paths defined...
+  │  - 'apps/*'
+  │  - 'packages/*'
+  -  - 'empty/*'   ← but this one doesn't match any package
+  -  - 'docs'   ← but this one doesn't match any package

--- a/src/rules/snapshots/sherif__rules__non_existant_packages__test__test.snap
+++ b/src/rules/snapshots/sherif__rules__non_existant_packages__test__test.snap
@@ -1,0 +1,9 @@
+---
+source: src/rules/non_existant_packages.rs
+expression: issue.message()
+---
+  │ packages:   ← Workspace has paths defined...
+  │  - 'apps/*'
+  │  - 'packages/*'
+  -  - 'empty/*'   ← but this one doesn't match any package
+  -  - 'docs'   ← but this one doesn't match any package


### PR DESCRIPTION
Closes https://github.com/QuiiBz/sherif/issues/23

All paths defined in the workspace (the root `package.json`' `workspaces` field or `pnpm-workspace.yaml`) should match at least one package.
