### PR TITLE
fix(multiple-dependency-versions): improve formatting for single packages

### DIFF
--- a/src/rules/multiple_dependency_versions.rs
+++ b/src/rules/multiple_dependency_versions.rs
@@ -74,11 +74,17 @@ impl Issue for MultipleDependencyVersionsIssue {
                     (version.to_string().yellow(), "∼ between".yellow())
                 };
 
-                let version_pad = " ".repeat(if end.len() > 26 { 3 } else { 26 - end.len() });
+                let version_pad = " ".repeat(if end.len() >= 26 { 3 } else { 26 - end.len() });
 
                 if group.is_empty() || group != common_path {
                     let root = common_path.join("/").bright_black();
                     group = common_path;
+
+                    if group.len() == 1 && group[0] == "." {
+                        let root = format!("{}{}", "./".bright_black(), end.bright_black());
+
+                        return format!("  {}  {}{}   {}", root, version_pad, version, indicator);
+                    }
 
                     return format!(
                         "  {}
@@ -122,9 +128,9 @@ mod test {
         let issue = MultipleDependencyVersionsIssue::new(
             "test".to_string(),
             indexmap::indexmap! {
-                "packages/package-a".into() => VersionReq::parse("1.2.3").unwrap(),
-                "packages/package-b".into() => VersionReq::parse("1.2.4").unwrap(),
-                "package-c".into() => VersionReq::parse("1.2.5").unwrap(),
+                "./packages/package-a".into() => VersionReq::parse("1.2.3").unwrap(),
+                "./packages/package-b".into() => VersionReq::parse("1.2.4").unwrap(),
+                "./package-c".into() => VersionReq::parse("1.2.5").unwrap(),
             },
         );
 
@@ -142,7 +148,7 @@ mod test {
         let issue = MultipleDependencyVersionsIssue::new(
             "test".to_string(),
             indexmap::indexmap! {
-                "package-a".into() => VersionReq::parse("1.2.3").unwrap(),
+                "./package-a".into() => VersionReq::parse("1.2.3").unwrap(),
             },
         );
 
@@ -155,9 +161,9 @@ mod test {
         let issue = MultipleDependencyVersionsIssue::new(
             "test".to_string(),
             indexmap::indexmap! {
-                "apps/package-a".into() => VersionReq::parse("5.6.3").unwrap(),
-                "apps/package-b".into() => VersionReq::parse("1.2.3").unwrap(),
-                "packages/package-c".into() => VersionReq::parse("3.1.6").unwrap(),
+                "./apps/package-a".into() => VersionReq::parse("5.6.3").unwrap(),
+                "./apps/package-b".into() => VersionReq::parse("1.2.3").unwrap(),
+                "./packages/package-c".into() => VersionReq::parse("3.1.6").unwrap(),
             },
         );
 
@@ -170,9 +176,9 @@ mod test {
         let issue = MultipleDependencyVersionsIssue::new(
             "test".to_string(),
             indexmap::indexmap! {
-                "package-a".into() => VersionReq::parse("1.2.3").unwrap(),
-                "packages/package-b".into() => VersionReq::parse("3.1.6").unwrap(),
-                "packages/package-c".into() => VersionReq::parse("3.1.6").unwrap(),
+                "./package-a".into() => VersionReq::parse("1.2.3").unwrap(),
+                "./packages/package-b".into() => VersionReq::parse("3.1.6").unwrap(),
+                "./packages/package-c".into() => VersionReq::parse("3.1.6").unwrap(),
             },
         );
 

--- a/src/rules/snapshots/sherif__rules__multiple_dependency_versions__test__dedupe.snap
+++ b/src/rules/snapshots/sherif__rules__multiple_dependency_versions__test__dedupe.snap
@@ -2,8 +2,7 @@
 source: src/rules/multiple_dependency_versions.rs
 expression: issue.message()
 ---
-  
-      package-a                 ^1.2.3   ↓ lowest
-  packages
+  ./package-a                   ^1.2.3   ↓ lowest
+  ./packages
       package-b                 ^3.1.6   ↑ highest
       package-c                 ^3.1.6   ↑ highest

--- a/src/rules/snapshots/sherif__rules__multiple_dependency_versions__test__order_multiple.snap
+++ b/src/rules/snapshots/sherif__rules__multiple_dependency_versions__test__order_multiple.snap
@@ -2,9 +2,9 @@
 source: src/rules/multiple_dependency_versions.rs
 expression: issue.message()
 ---
-  apps
+  ./apps
       package-b                 ^1.2.3   ↓ lowest
-  packages
+  ./packages
       package-c                 ^3.1.6   ∼ between
-  apps
+  ./apps
       package-a                 ^5.6.3   ↑ highest

--- a/src/rules/snapshots/sherif__rules__multiple_dependency_versions__test__order_single.snap
+++ b/src/rules/snapshots/sherif__rules__multiple_dependency_versions__test__order_single.snap
@@ -2,5 +2,4 @@
 source: src/rules/multiple_dependency_versions.rs
 expression: issue.message()
 ---
-  
-      package-a                 ^1.2.3   ↑ highest
+  ./package-a                   ^1.2.3   ↑ highest


### PR DESCRIPTION
It looks a lot better like this:

<img width="1249" alt="Screenshot 2023-11-11 at 14 01 43" src="https://github.com/QuiiBz/sherif/assets/43268759/86e5412f-6c7d-4666-a288-894ae989dc7e">
