### PR TITLE
feat: autofix `packages-without-package-json`

### DIFF
--- a/src/collect.rs
+++ b/src/collect.rs
@@ -51,7 +51,6 @@ pub fn collect_packages(args: &Args) -> Result<PackagesList> {
             Ok(package) => packages.push(package),
             Err(error) => {
                 if error.to_string().contains("not found") {
-                    println!("{}", error);
                     packages_issues.push(PackagesWithoutPackageJsonIssue::new(
                         path.to_string_lossy().to_string(),
                     ));

--- a/src/collect.rs
+++ b/src/collect.rs
@@ -50,7 +50,8 @@ pub fn collect_packages(args: &Args) -> Result<PackagesList> {
         |packages_issues: &mut Vec<BoxIssue>, path: PathBuf| match Package::new(path.clone()) {
             Ok(package) => packages.push(package),
             Err(error) => {
-                if error.to_string().contains("package.json") {
+                if error.to_string().contains("not found") {
+                    println!("{}", error);
                     packages_issues.push(PackagesWithoutPackageJsonIssue::new(
                         path.to_string_lossy().to_string(),
                     ));
@@ -170,8 +171,10 @@ pub fn collect_issues(args: &Args, packages_list: PackagesList) -> IssuesList<'_
     let mut all_dependencies = IndexMap::new();
 
     for package in packages {
-        if args.ignore_package.contains(package.get_name()) {
-            continue;
+        if let Some(package_name) = package.get_name() {
+            if args.ignore_package.contains(package_name) {
+                continue;
+            }
         }
 
         let package_type = PackageType::Package(package.get_path());
@@ -402,7 +405,7 @@ mod test {
 
         let mut packages = packages
             .into_iter()
-            .map(|package| package.get_name().to_string())
+            .map(|package| package.get_name().clone().unwrap().to_string())
             .collect::<Vec<_>>();
         packages.sort();
 

--- a/src/packages/mod.rs
+++ b/src/packages/mod.rs
@@ -19,7 +19,7 @@ pub struct PackagesList {
 
 #[derive(Deserialize, Debug)]
 struct PackageInner {
-    name: String,
+    name: Option<String>,
     private: Option<bool>,
     workspaces: Option<Vec<String>>,
     dependencies: Option<IndexMap<String, String>>,
@@ -61,7 +61,7 @@ impl Package {
         })
     }
 
-    pub fn get_name(&self) -> &String {
+    pub fn get_name(&self) -> &Option<String> {
         &self.inner.name
     }
 

--- a/src/packages/root.rs
+++ b/src/packages/root.rs
@@ -18,8 +18,8 @@ impl RootPackage {
     }
 
     #[cfg(test)]
-    pub fn get_name(&self) -> &String {
-        self.0.get_name()
+    pub fn get_name(&self) -> String {
+        self.0.get_name().clone().unwrap_or_default()
     }
 
     pub fn get_workspaces(&self) -> Option<Vec<String>> {

--- a/src/rules/root_package_private_field.rs
+++ b/src/rules/root_package_private_field.rs
@@ -50,10 +50,10 @@ impl Issue for RootPackagePrivateFieldIssue {
             let value = fs::read_to_string(&path)?;
             let mut value = serde_json::from_str::<serde_json::Value>(&value)?;
 
-            value.as_object_mut().unwrap().insert(
-                "private".to_string(),
-                serde_json::Value::String("true".to_string()),
-            );
+            value
+                .as_object_mut()
+                .unwrap()
+                .insert("private".to_string(), serde_json::Value::Bool(true));
 
             let value = serde_json::to_string_pretty(&value)?;
             fs::write(path, value)?;


### PR DESCRIPTION
Relates to https://github.com/QuiiBz/sherif/issues/6

- Also fix this same rule from being caught when a package did not have a `name` field (which is technically possible)
- Also fix `root-package-private-field` autofix writing `"true"` instead of `true`