### PR TITLE
fix(root-package-manager-field): wrong detection

### DIFF
--- a/src/packages/mod.rs
+++ b/src/packages/mod.rs
@@ -22,6 +22,8 @@ struct PackageInner {
     name: Option<String>,
     private: Option<bool>,
     workspaces: Option<Vec<String>>,
+    #[serde(rename = "packageManager")]
+    package_manager: Option<String>,
     dependencies: Option<IndexMap<String, String>>,
     #[serde(rename = "devDependencies")]
     dev_dependencies: Option<IndexMap<String, String>>,

--- a/src/packages/root.rs
+++ b/src/packages/root.rs
@@ -34,7 +34,7 @@ impl RootPackage {
     }
 
     pub fn check_package_manager(&self) -> Option<BoxIssue> {
-        match self.0.inner.private.is_none() {
+        match self.0.inner.package_manager.is_none() {
             true => Some(RootPackageManagerFieldIssue::new()),
             false => None,
         }


### PR DESCRIPTION
The check to show this rule was checking the presence of the `private` field instead of the `packageManager` field of the root package.