### PR TITLE
feat: allow paths and globs for `--ignore-package`

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,13 @@ You can ignore a specific rule by using `--ignore-rule <name>` (or `-r <name>`):
 sherif -r packages-without-package-json -r root-package-manager-field
 ```
 
-You can ignore all issues in a package by using `--ignore-package <name>` (or `-p <name>`):
+You can ignore all issues in a package by using `--ignore-package <pathOrName>` (or `-p <pathOrName>`):
 
 ```bash
-# Ignore all issues in the package
+# Ignore all issues in the `@repo/tools` package
 sherif -p @repo/tools
+# Ignore all issues for packages inside `./integrations/*`
+sherif -p ./integrations/*
 ```
 
 > **Note**

--- a/src/args.rs
+++ b/src/args.rs
@@ -15,7 +15,7 @@ pub struct Args {
     #[arg(long, short)]
     pub ignore_dependency: Vec<String>,
 
-    /// Ignore rules for the given package name.
+    /// Ignore rules for the given package name or path.
     #[arg(long, short = 'p')]
     pub ignore_package: Vec<String>,
 

--- a/src/collect.rs
+++ b/src/collect.rs
@@ -199,10 +199,8 @@ pub fn collect_issues(args: &Args, packages_list: PackagesList) -> IssuesList<'_
     let mut all_dependencies = IndexMap::new();
 
     for package in packages {
-        if let Some(package_name) = package.get_name() {
-            if args.ignore_package.contains(package_name) {
-                continue;
-            }
+        if package.is_ignored(&args.ignore_package) {
+            continue;
         }
 
         let package_type = PackageType::Package(package.get_path());

--- a/src/packages/mod.rs
+++ b/src/packages/mod.rs
@@ -142,4 +142,21 @@ impl Package {
     pub fn get_dev_dependencies(&self) -> Option<IndexMap<String, SemVersion>> {
         self.get_deps(&self.inner.dev_dependencies)
     }
+
+    pub fn is_ignored(&self, ignored_packages: &[String]) -> bool {
+        match self.get_name() {
+            Some(name) => ignored_packages.iter().any(|ignored_package| {
+                match ignored_package.ends_with('*') {
+                    true => {
+                        let ignored_package = ignored_package.trim_end_matches('*');
+
+                        name.starts_with(ignored_package)
+                            || self.get_path().starts_with(ignored_package)
+                    }
+                    false => ignored_package == name || ignored_package == &self.get_path(),
+                }
+            }),
+            None => false,
+        }
+    }
 }


### PR DESCRIPTION
Closes https://github.com/QuiiBz/sherif/issues/41

- `--ignore-package` now supports specifying a path to a specific package
- `--ignore-package` now supports globs

Examples:

```bash
# Ignore all issues in the `@repo/tools` package
sherif -p @repo/tools
# Ignore all issues for packages name matching `@repo-internal/*`
sherif -p @repo-internal/*
# Ignore all issues in the package inside `./integrations/react`
sherif -p ./integrations/react
# Ignore all issues for packages inside `./integrations/*`
sherif -p ./integrations/*
```