### PR TITLE
perf: reduce binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,10 @@ serde_yaml = "0.9.25"
 [dev-dependencies]
 debugless-unwrap = "0.0.4"
 insta = "1.32.0"
+
+[profile.release]
+strip = "symbols"
+opt-level = "z"
+lto = "thin"
+codegen-units = 1
+panic = "abort"


### PR DESCRIPTION
From 2.2MB to 1.1MB on `aarch64-apple-darwin`:

<img width="421" alt="Screenshot 2023-12-25 at 14 31 12" src="https://github.com/QuiiBz/sherif/assets/43268759/62d35cc1-d22b-4b51-b336-1d6f500f4cf9">
