### PR TITLE
chore: update ignoring with star example

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ You can ignore all issues in a package by using `--ignore-package <pathOrName>` 
 # Ignore all issues in the `@repo/tools` package
 sherif -p @repo/tools
 # Ignore all issues for packages inside `./integrations/*`
-sherif -p ./integrations/*
+sherif -p "./integrations/*"
 ```
 
 > **Note**


### PR DESCRIPTION
Closes https://github.com/QuiiBz/sherif/issues/51

Explanation of the issue here: https://github.com/TanStack/query/pull/6701#issuecomment-1903834659
TL;DR: it's not a bug in Sherif, but some shell might interpret and expand `*` so the command is invalid, unless you wrap the argument in quotes.
