### PR TITLE
feat: preserve JSON indentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,6 +199,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f400d0750c0c069e8493f2256cb4da6f604b6d2eeb69a0ca8863acde352f8400"
 
 [[package]]
+name = "detect-indent"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae11867b75e44bacc8baf64be8abe6501c6571bbf33fed819a0a90623c82d1b"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,6 +363,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
+name = "memchr"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+
+[[package]]
 name = "mio"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,6 +438,35 @@ checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
 ]
+
+[[package]]
+name = "regex"
+version = "1.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "rustix"
@@ -498,6 +552,7 @@ dependencies = [
  "clap",
  "colored",
  "debugless-unwrap",
+ "detect-indent",
  "indexmap",
  "inquire",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ readme = "./README.md"
 anyhow = "1.0.75"
 clap = { version = "4.4.3", features = ["derive"] }
 colored = "2.0.4"
+detect-indent = "0.1.0"
 indexmap = { version = "2.0.0", features = ["serde"] }
 inquire = "0.6.2"
 semver = "1.0.18"

--- a/src/json.rs
+++ b/src/json.rs
@@ -1,0 +1,28 @@
+use anyhow::Result;
+use detect_indent::{detect_indent, Indent};
+use serde::{Deserialize, Serialize};
+use serde_json::ser::PrettyFormatter;
+
+pub fn deserialize<'a, T>(value: &'a str) -> Result<(T, Indent)>
+where
+    T: Deserialize<'a>,
+{
+    let json = serde_json::from_str::<T>(value)?;
+    let indent = detect_indent(value);
+
+    Ok((json, indent))
+}
+
+pub fn serialize<T>(value: &T, indent: &Indent) -> Result<String>
+where
+    T: Serialize,
+{
+    let mut buf = Vec::new();
+    let formatter = PrettyFormatter::with_indent(indent.indent().as_bytes());
+    let mut serializer = serde_json::Serializer::with_formatter(&mut buf, formatter);
+
+    value.serialize(&mut serializer)?;
+    let json = String::from_utf8(buf)?;
+
+    Ok(json)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use std::time::Instant;
 
 mod args;
 mod collect;
+mod json;
 mod packages;
 mod plural;
 mod printer;

--- a/src/rules/empty_dependencies.rs
+++ b/src/rules/empty_dependencies.rs
@@ -1,4 +1,5 @@
 use super::{Issue, IssueLevel, PackageType};
+use crate::json::{self};
 use anyhow::Result;
 use colored::Colorize;
 use std::{borrow::Cow, fmt::Display, fs, path::PathBuf};
@@ -71,7 +72,7 @@ impl Issue for EmptyDependenciesIssue {
         if let PackageType::Package(path) = package_type {
             let path = PathBuf::from(path).join("package.json");
             let value = fs::read_to_string(&path)?;
-            let mut value = serde_json::from_str::<serde_json::Value>(&value)?;
+            let (mut value, indent) = json::deserialize::<serde_json::Value>(&value)?;
             let dependency = self.dependency_kind.to_string();
 
             if let Some(dependency_field) = value.get(&dependency) {
@@ -79,7 +80,7 @@ impl Issue for EmptyDependenciesIssue {
                 {
                     value.as_object_mut().unwrap().remove(&dependency);
 
-                    let value = serde_json::to_string_pretty(&value)?;
+                    let value = json::serialize(&value, &indent)?;
                     fs::write(path, value)?;
 
                     self.fixed = true;

--- a/src/rules/multiple_dependency_versions.rs
+++ b/src/rules/multiple_dependency_versions.rs
@@ -1,5 +1,5 @@
 use super::{Issue, IssueLevel, PackageType};
-use crate::packages::semversion::SemVersion;
+use crate::{json, packages::semversion::SemVersion};
 use anyhow::Result;
 use colored::Colorize;
 use indexmap::IndexMap;
@@ -144,7 +144,7 @@ impl Issue for MultipleDependencyVersionsIssue {
             for package in self.versions.keys() {
                 let path = PathBuf::from(package).join("package.json");
                 let value = fs::read_to_string(&path)?;
-                let mut value = serde_json::from_str::<serde_json::Value>(&value)?;
+                let (mut value, indent) = json::deserialize::<serde_json::Value>(&value)?;
 
                 if let Some(dependencies) = value.get_mut("dependencies") {
                     let dependencies = dependencies.as_object_mut().unwrap();
@@ -162,7 +162,7 @@ impl Issue for MultipleDependencyVersionsIssue {
                     }
                 }
 
-                let value = serde_json::to_string_pretty(&value)?;
+                let value = json::serialize(&value, &indent)?;
                 fs::write(path, value)?;
             }
 

--- a/src/rules/non_existant_packages.rs
+++ b/src/rules/non_existant_packages.rs
@@ -1,4 +1,5 @@
 use super::{Issue, IssueLevel, PackageType};
+use crate::json;
 use anyhow::Result;
 use colored::Colorize;
 use std::{borrow::Cow, fs, path::PathBuf};
@@ -127,7 +128,7 @@ impl Issue for NonExistantPackagesIssue {
                 false => {
                     let path = PathBuf::from("package.json");
                     let value = fs::read_to_string(&path)?;
-                    let mut value = serde_json::from_str::<serde_json::Value>(&value)?;
+                    let (mut value, indent) = json::deserialize::<serde_json::Value>(&value)?;
 
                     value
                         .get_mut("workspaces")
@@ -140,7 +141,7 @@ impl Issue for NonExistantPackagesIssue {
                             !self.paths.contains(&package)
                         });
 
-                    let value = serde_json::to_string_pretty(&value)?;
+                    let value = json::serialize(&value, &indent)?;
                     fs::write(path, value)?;
 
                     self.fixed = true;

--- a/src/rules/root_package_private_field.rs
+++ b/src/rules/root_package_private_field.rs
@@ -1,4 +1,5 @@
 use super::{Issue, IssueLevel, PackageType};
+use crate::json;
 use anyhow::Result;
 use colored::Colorize;
 use std::{borrow::Cow, fs, path::PathBuf};
@@ -48,14 +49,14 @@ impl Issue for RootPackagePrivateFieldIssue {
         if let PackageType::Root = package_type {
             let path = PathBuf::from("package.json");
             let value = fs::read_to_string(&path)?;
-            let mut value = serde_json::from_str::<serde_json::Value>(&value)?;
+            let (mut value, indent) = json::deserialize::<serde_json::Value>(&value)?;
 
             value
                 .as_object_mut()
                 .unwrap()
                 .insert("private".to_string(), serde_json::Value::Bool(true));
 
-            let value = serde_json::to_string_pretty(&value)?;
+            let value = json::serialize(&value, &indent)?;
             fs::write(path, value)?;
 
             self.fixed = true;

--- a/src/rules/types_in_dependencies.rs
+++ b/src/rules/types_in_dependencies.rs
@@ -1,4 +1,5 @@
 use super::{Issue, IssueLevel, PackageType};
+use crate::json;
 use anyhow::Result;
 use colored::Colorize;
 use indexmap::IndexMap;
@@ -84,7 +85,7 @@ impl Issue for TypesInDependenciesIssue {
         if let PackageType::Package(path) = package_type {
             let path = PathBuf::from(path).join("package.json");
             let value = fs::read_to_string(&path)?;
-            let mut value = serde_json::from_str::<serde_json::Value>(&value)?;
+            let (mut value, indent) = json::deserialize::<serde_json::Value>(&value)?;
 
             let dependencies = value
                 .get_mut("dependencies")
@@ -118,7 +119,7 @@ impl Issue for TypesInDependenciesIssue {
                 dev_dependencies.insert(package, version);
             }
 
-            let value = serde_json::to_string_pretty(&value)?;
+            let value = json::serialize(&value, &indent)?;
             fs::write(path, value)?;
 
             self.fixed = true;


### PR DESCRIPTION
Closes https://github.com/QuiiBz/sherif/issues/54

Using the [`detect-indent`](https://github.com/stefanpenner/detect-indent-rs) crate and `serde_json`'s [`PrettyFormatter`](https://docs.rs/serde_json/latest/serde_json/ser/struct.PrettyFormatter.html#impl-Formatter-for-PrettyFormatter%3C'a%3E), we can preserve the correct indentation.