### PR TITLE
feat: improve multiple-dependency-versions fix style

### DIFF
--- a/src/rules/multiple_dependency_versions.rs
+++ b/src/rules/multiple_dependency_versions.rs
@@ -113,7 +113,7 @@ impl Issue for MultipleDependencyVersionsIssue {
     }
 
     fn fix(&mut self, _package_type: &PackageType) -> Result<()> {
-        let message = format!("Select the version of {} to use:", self.name).bold();
+        let message = format!("Select the version of {} to use:", self.name.bold());
 
         let mut sorted_versions = self.versions.values().collect::<Vec<_>>();
         sorted_versions.sort_by(|a, b| b.cmp(a));


### PR DESCRIPTION
Improve the style of `multiple-dependency-versions` when autofixing with `--fix` to make the dependency name bold, so easier to see:

Before:
<img width="394" alt="Screenshot 2024-07-06 at 09 05 21" src="https://github.com/QuiiBz/sherif/assets/43268759/8e7fd227-0608-4a7c-8b6a-9860f0ddbb6b">

After:
<img width="409" alt="Screenshot 2024-07-06 at 09 05 09" src="https://github.com/QuiiBz/sherif/assets/43268759/fe21dff8-c921-49b8-8ddd-793ef5ed1ec3">

