### PR TITLE
fix: macos runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,13 +40,13 @@ jobs:
             }
           - {
               NAME: darwin-x64,
-              OS: macos-11,
+              OS: macos-13,
               TOOLCHAIN: stable,
               TARGET: x86_64-apple-darwin,
             }
           - {
               NAME: darwin-arm64,
-              OS: macos-11,
+              OS: macos-13,
               TOOLCHAIN: stable,
               TARGET: aarch64-apple-darwin,
             }


### PR DESCRIPTION
MacOS 11 has been deprecated: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
So it runs indefinitely: https://github.com/QuiiBz/sherif/actions/runs/9826255490/job/27127484128#logs