### PR TITLE
feat: `multiple-dependency-versions` also checks root package

### DIFF
--- a/src/packages/root.rs
+++ b/src/packages/root.rs
@@ -1,10 +1,11 @@
-use super::{Package, Workspaces};
+use super::{semversion::SemVersion, Package, Workspaces};
 use crate::rules::{
     root_package_dependencies::RootPackageDependenciesIssue,
     root_package_manager_field::RootPackageManagerFieldIssue,
     root_package_private_field::RootPackagePrivateFieldIssue, BoxIssue,
 };
 use anyhow::Result;
+use indexmap::IndexMap;
 use std::path::Path;
 
 #[derive(Debug)]
@@ -20,6 +21,10 @@ impl RootPackage {
     #[cfg(test)]
     pub fn get_name(&self) -> String {
         self.0.get_name().clone().unwrap_or_default()
+    }
+
+    pub fn get_path(&self) -> String {
+        self.0.get_path()
     }
 
     pub fn get_workspaces(&self) -> Option<Vec<String>> {
@@ -63,5 +68,13 @@ impl RootPackage {
 
     pub fn check_optional_dependencies(&self) -> Option<BoxIssue> {
         self.0.check_optional_dependencies()
+    }
+
+    pub fn get_dependencies(&self) -> Option<IndexMap<String, SemVersion>> {
+        self.0.get_dependencies()
+    }
+
+    pub fn get_dev_dependencies(&self) -> Option<IndexMap<String, SemVersion>> {
+        self.0.get_dev_dependencies()
     }
 }

--- a/src/rules/snapshots/sherif__rules__multiple_dependency_versions__test__root.snap
+++ b/src/rules/snapshots/sherif__rules__multiple_dependency_versions__test__root.snap
@@ -1,0 +1,8 @@
+---
+source: src/rules/multiple_dependency_versions.rs
+expression: issue.message()
+---
+  ./packages
+      package-a                 1.2.3   ↓ lowest
+      package-b                 3.1.6   ∼ between
+  ./                            5.6.3   ↑ highest


### PR DESCRIPTION
Closes #81

`multiple-dependency-versions` didn't check the root `package.json` dependencies, so we could still have multiple dependencies versions in the workspace.