### PR TITLE
feat: allow ignoring specific dependency and version for `multiple-dependency-versions`

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ sherif -p @repo/tools
 sherif -p "./integrations/*"
 ```
 
-> **Note**
+> **Note*13.2.4*
 > Sherif doesn't have many rules for now, but will likely have more in the future (along with more features).
 
 #### `empty-dependencies` ❌
@@ -93,11 +93,14 @@ sherif -p "./integrations/*"
 
 A given dependency should use the same version across the monorepo.
 
-You can ignore this rule for a dependency if you expect to have multiple versions by using `--ignore-dependency <name>` (or `-i <name>`):
+You can ignore this rule for a specific dependency and version or all versions of a dependency if it's expected in your monorepo by using `--ignore-dependency <name@version>` / `--ignore-dependency <name>` (or `-i <name@version>` / `-i <name>`):
 
 ```bash
-# Ignore dependencies that are expected to have multiple versions
-sherif -i react -i @types/node
+# Ignore only the specific dependency version mismatch
+sherif -i react@17.0.2 -i next@13.2.4
+
+# Completely ignore all versions mismatch of these dependencies
+sherif -i react -i next
 ```
 
 #### `non-existant-packages` ⚠️

--- a/src/args.rs
+++ b/src/args.rs
@@ -11,7 +11,7 @@ pub struct Args {
     #[arg(long)]
     pub fix: bool,
 
-    /// Ignore the `multiple-dependency-versions` rule for the given dependency name.
+    /// Ignore the `multiple-dependency-versions` rule for the given dependency name and/or version.
     #[arg(long, short)]
     pub ignore_dependency: Vec<String>,
 

--- a/src/packages/semversion.rs
+++ b/src/packages/semversion.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Result};
 use semver::{Version, VersionReq};
 use std::{cmp::Ordering, fmt::Display};
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum SemVersion {
     Exact(Version),
     Range(VersionReq),

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -71,7 +71,7 @@ pub fn print_footer(
     );
     println!(
         "{}",
-        " Note: use `-a` / `-i` to ignore dependencies, `-r` to ignore rules, `-p` to ignore packages, and `--fix` to autofix fixable issues."
+        " Note: use `-i` to ignore dependencies, `-r` to ignore rules, `-p` to ignore packages, and `--fix` to autofix fixable issues."
             .bright_black()
     );
 }

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -71,7 +71,7 @@ pub fn print_footer(
     );
     println!(
         "{}",
-        " Note: use `-i` to ignore dependencies, `-r` to ignore rules, `-p` to ignore packages, and `--fix` to autofix fixable issues."
+        " Note: use `-a` / `-i` to ignore dependencies, `-r` to ignore rules, `-p` to ignore packages, and `--fix` to autofix fixable issues."
             .bright_black()
     );
 }


### PR DESCRIPTION
Closes https://github.com/QuiiBz/sherif/issues/83

This updates the `--ignore-dependency / `-i` option to allow passing `dependency@version` arguments instead of only a dependency name.