### PR TITLE
feat: expand nested packages

### DIFF
--- a/fixtures/dependencies-nested-star/package.json
+++ b/fixtures/dependencies-nested-star/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "dependencies-nested-star",
+  "workspaces": [
+    "packages/**/*",
+    "packages/docs"
+  ],
+  "private": true,
+  "packageManager": "pnpm@1.2.3",
+  "devDependencies": {
+    "eslint": "1.2.3",
+    "prettier": "1.2.3"
+  }
+}

--- a/fixtures/dependencies-nested-star/packages/docs/package.json
+++ b/fixtures/dependencies-nested-star/packages/docs/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "docs",
+  "dependencies": {
+    "next": "1.2.3",
+    "eslint": "7.8.9",
+    "react": "*"
+  }
+}

--- a/fixtures/dependencies-nested-star/packages/other/abc/package.json
+++ b/fixtures/dependencies-nested-star/packages/other/abc/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "abc",
+  "dependencies": {
+    "next": "4.5.6",
+    "react": "1.2.3"
+  }
+}

--- a/fixtures/dependencies-nested-star/packages/other/def/package.json
+++ b/fixtures/dependencies-nested-star/packages/other/def/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "def",
+  "dependencies": {
+    "next": "1.2.3",
+    "react": "1.2.3"
+  }
+}

--- a/src/collect.rs
+++ b/src/collect.rs
@@ -96,20 +96,18 @@ pub fn collect_packages(args: &Args) -> Result<PackagesList> {
 
                 match directory.read_dir() {
                     Ok(expanded_folders) => {
-                        for expanded_folder in expanded_folders {
-                            if let Ok(expanded_folder) = expanded_folder {
-                                let expanded_folder = expanded_folder.path();
+                        for expanded_folder in expanded_folders.flatten() {
+                            let expanded_folder = expanded_folder.path();
 
-                                if expanded_folder.is_dir() {
-                                    let path =
-                                        expanded_folder.to_string_lossy().to_string().replace(
-                                            &(args.path.to_string_lossy().to_string() + "/"),
-                                            "",
-                                        ) + "/"
-                                            + subdirectory;
+                            if expanded_folder.is_dir() {
+                                let path = expanded_folder
+                                    .to_string_lossy()
+                                    .to_string()
+                                    .replace(&(args.path.to_string_lossy().to_string() + "/"), "")
+                                    + "/"
+                                    + subdirectory;
 
-                                    expanded_packages.push(path);
-                                }
+                                expanded_packages.push(path);
                             }
                         }
                     }


### PR DESCRIPTION
Closes https://github.com/QuiiBz/sherif/issues/88

Allow expanding packages defined in the workspace using `**`. This will expand by one level of folder and can only be used once.

For example, `packages/**/*` is now supported.