### PR TITLE
fix: exit when parsing `package.json` fails

### DIFF
--- a/src/collect.rs
+++ b/src/collect.rs
@@ -57,6 +57,7 @@ pub fn collect_packages(args: &Args) -> Result<PackagesList> {
                     ));
                 } else {
                     print_error("Failed to collect package", &error.to_string());
+                    std::process::exit(1);
                 }
             }
         };


### PR DESCRIPTION
Closes https://github.com/QuiiBz/sherif/issues/103

Similar to when we close `collect_packages`, we should exit after we fail to parse a single `package.json` (often due to an incorrect field).