### PR TITLE
feat: `unsync-similar-dependencies` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ sherif -i react@17.0.2 -i next@13.2.4
 sherif -i react -i next
 ```
 
+### `unsync-similar-dependencies` ❌
+
+Similar dependencies in a given `package.json` should use the same version. For example, if you use both `react` and `react-dom` dependencies in the same `package.json`, this rule will enforce that they use the same version.
+
 #### `non-existant-packages` ⚠️
 
 All paths defined in the workspace (the root `package.json`' `workspaces` field or `pnpm-workspace.yaml`) should match at least one package.

--- a/README.md
+++ b/README.md
@@ -131,6 +131,17 @@ sherif -i react -i next
 
 Similar dependencies in a given `package.json` should use the same version. For example, if you use both `react` and `react-dom` dependencies in the same `package.json`, this rule will enforce that they use the same version.
 
+<details>
+
+<summary>List of detected similar dependencies</summary>
+
+- `react`, `react-dom`
+- `next`, `@next/eslint-plugin-next`, `eslint-config-next`, `@next/bundle-analyzer`, `@next/third-parties`, `@next/mdx`
+- `turbo`,  `turbo-ignore`, `eslint-config-turbo`, `eslint-plugin-turbo`, `@turbo/gen`, `@turbo/workspaces`
+- `@tanstack/eslint-plugin-query`, `@tanstack/query-async-storage-persister`, `@tanstack/query-broadcast-client-experimental`, `@tanstack/query-core`, `@tanstack/query-devtools`, `@tanstack/query-persist-client-core`, `@tanstack/query-sync-storage-persister`, `@tanstack/react-query`, `@tanstack/react-query-devtools`, `@tanstack/react-query-persist-client`, `@tanstack/react-query-next-experimental`, `@tanstack/solid-query`, `@tanstack/solid-query-devtools`, `@tanstack/solid-query-persist-client`, `@tanstack/svelte-query`, `@tanstack/svelte-query-devtools`, `@tanstack/svelte-query-persist-client`, `@tanstack/vue-query`, `@tanstack/vue-query-devtools`, `@tanstack/angular-query-devtools-experimental`, `@tanstack/angular-query-experimental`
+
+</details>
+
 #### `non-existant-packages` ⚠️
 
 All paths defined in the workspace (the root `package.json`' `workspaces` field or `pnpm-workspace.yaml`) should match at least one package.

--- a/README.md
+++ b/README.md
@@ -141,8 +141,8 @@ Similar dependencies in a given `package.json` should use the same version. For 
 <summary>List of detected similar dependencies</summary>
 
 - `react`, `react-dom`
-- `next`, `@next/eslint-plugin-next`, `eslint-config-next`, `@next/bundle-analyzer`, `@next/third-parties`, `@next/mdx`
-- `turbo`,  `turbo-ignore`, `eslint-config-turbo`, `eslint-plugin-turbo`, `@turbo/gen`, `@turbo/workspaces`
+- `eslint-config-next`, `@next/eslint-plugin-next`, `@next/font` `@next/bundle-analyzer`, `@next/third-parties`, `@next/mdx`, `next`
+- `eslint-config-turbo`, `eslint-plugin-turbo`, `@turbo/gen`, `turbo-ignore`, `turbo`
 - `@tanstack/eslint-plugin-query`, `@tanstack/query-async-storage-persister`, `@tanstack/query-broadcast-client-experimental`, `@tanstack/query-core`, `@tanstack/query-devtools`, `@tanstack/query-persist-client-core`, `@tanstack/query-sync-storage-persister`, `@tanstack/react-query`, `@tanstack/react-query-devtools`, `@tanstack/react-query-persist-client`, `@tanstack/react-query-next-experimental`, `@tanstack/solid-query`, `@tanstack/solid-query-devtools`, `@tanstack/solid-query-persist-client`, `@tanstack/svelte-query`, `@tanstack/svelte-query-devtools`, `@tanstack/svelte-query-persist-client`, `@tanstack/vue-query`, `@tanstack/vue-query-devtools`, `@tanstack/angular-query-devtools-experimental`, `@tanstack/angular-query-experimental`
 
 </details>

--- a/fixtures/unsync/package.json
+++ b/fixtures/unsync/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "unsync",
+  "private": true,
+  "packageManager": "pnpm@7.0.0",
+  "workspaces": [
+    "packages/*"
+  ]
+}

--- a/fixtures/unsync/packages/abc/package.json
+++ b/fixtures/unsync/packages/abc/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "abc",
+  "dependencies": {
+    "react": "2.0.0"
+  }
+}

--- a/fixtures/unsync/packages/def/package.json
+++ b/fixtures/unsync/packages/def/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "def",
+  "dependencies": {
+    "react": "1.0.0",
+    "turbo": "2.0.0",
+    "turbo-ignore": "3.0.0"
+  }
+}

--- a/src/collect.rs
+++ b/src/collect.rs
@@ -803,4 +803,35 @@ mod test {
             "unordered-dependencies"
         );
     }
+
+    #[test]
+    fn collect_unsync_similar_dependencies() {
+        let args = Args {
+            path: "fixtures/unsync".into(),
+            fix: false,
+            no_install: false,
+            ignore_rule: Vec::new(),
+            ignore_package: Vec::new(),
+            ignore_dependency: Vec::new(),
+        };
+
+        let packages_list = collect_packages(&args).unwrap();
+        assert_eq!(packages_list.root_package.get_name(), "unsync");
+        assert_eq!(packages_list.packages.len(), 2);
+
+        let issues = collect_issues(&args, packages_list);
+        assert_eq!(issues.total_len(), 2);
+
+        let issues = issues.into_iter().collect::<IndexMap<_, _>>();
+
+        assert_eq!(
+            issues
+                .get(&PackageType::Package(
+                    "fixtures/unsync/packages/def".to_string()
+                ))
+                .unwrap()[0]
+                .name(),
+            "unsync-similar-dependencies"
+        );
+    }
 }

--- a/src/collect.rs
+++ b/src/collect.rs
@@ -310,22 +310,14 @@ pub fn collect_issues(args: &Args, packages_list: PackagesList) -> IssuesList<'_
     for (name, versions) in all_dependencies {
         if let Ok(similar_dependency) = SimilarDependency::try_from(name.as_str()) {
             for (path, version) in versions.iter() {
-                let map = similar_dependencies_by_package
+                similar_dependencies_by_package
                     .entry(path.clone())
                     .or_insert_with(
                         IndexMap::<SimilarDependency, IndexMap<SemVersion, String>>::new,
-                    );
-
-                if map.contains_key(&similar_dependency) {
-                    map.get_mut(&similar_dependency)
-                        .unwrap()
-                        .insert(version.clone(), name.clone());
-                } else {
-                    map.insert(
-                        similar_dependency.clone(),
-                        [(version.clone(), name.clone())].iter().cloned().collect(),
-                    );
-                }
+                    )
+                    .entry(similar_dependency.clone())
+                    .or_insert_with(IndexMap::new)
+                    .insert(version.clone(), name.clone());
             }
         }
 

--- a/src/packages/semversion.rs
+++ b/src/packages/semversion.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Result};
 use semver::{Prerelease, Version, VersionReq};
 use std::{cmp::Ordering, fmt::Display};
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub enum SemVersion {
     Exact(Version),
     Range(VersionReq),

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -12,6 +12,7 @@ pub mod root_package_manager_field;
 pub mod root_package_private_field;
 pub mod types_in_dependencies;
 pub mod unordered_dependencies;
+pub mod unsync_similar_dependencies;
 
 pub const ERROR: &str = "⨯";
 pub const WARNING: &str = "⚠️";

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -1,7 +1,10 @@
 use anyhow::{anyhow, Result};
 use colored::Colorize;
 use indexmap::IndexMap;
-use std::{borrow::Cow, fmt::Display};
+use std::{
+    borrow::Cow,
+    fmt::{Debug, Display},
+};
 
 pub mod empty_dependencies;
 pub mod multiple_dependency_versions;

--- a/src/rules/snapshots/sherif__rules__unsync_similar_dependencies__tests__basic.snap
+++ b/src/rules/snapshots/sherif__rules__unsync_similar_dependencies__tests__basic.snap
@@ -1,0 +1,10 @@
+---
+source: src/rules/unsync_similar_dependencies.rs
+expression: issue.message()
+---
+  │ {
+  │   "dependencies": {
+  ~      "react": "1.0.0",
+  ~      "react-dom": "2.0.0"
+  │   }
+  │ }

--- a/src/rules/unsync_similar_dependencies.rs
+++ b/src/rules/unsync_similar_dependencies.rs
@@ -29,18 +29,18 @@ impl TryFrom<&str> for SimilarDependency {
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         match value {
             "react" | "react-dom" => Ok(Self::React),
-            "next"
+            "eslint-config-next"
             | "@next/eslint-plugin-next"
-            | "eslint-config-next"
+            | "@next/font"
             | "@next/bundle-analyzer"
-            | "@next/third-parties"
-            | "@next/mdx" => Ok(Self::NextJS),
-            "turbo"
-            | "turbo-ignore"
-            | "eslint-config-turbo"
+            | "@next/mdx"
+            | "next"
+            | "@next/third-parties" => Ok(Self::NextJS),
+            "eslint-config-turbo"
             | "eslint-plugin-turbo"
             | "@turbo/gen"
-            | "@turbo/workspaces" => Ok(Self::Turborepo),
+            | "turbo-ignore"
+            | "turbo" => Ok(Self::Turborepo),
             "@tanstack/eslint-plugin-query"
             | "@tanstack/query-async-storage-persister"
             | "@tanstack/query-broadcast-client-experimental"

--- a/src/rules/unsync_similar_dependencies.rs
+++ b/src/rules/unsync_similar_dependencies.rs
@@ -125,7 +125,10 @@ impl Issue for UnsyncSimilarDependenciesIssue {
     }
 
     fn why(&self) -> Cow<'static, str> {
-        Cow::Owned(format!("{} dependencies aren't synced.", self.r#type))
+        Cow::Owned(format!(
+            "Similar {} dependencies should use the same version.",
+            self.r#type
+        ))
     }
 
     fn fix(&mut self, _package_type: &super::PackageType) -> anyhow::Result<()> {
@@ -152,7 +155,10 @@ mod tests {
         assert_eq!(issue.name(), "unsync-similar-dependencies");
         assert_eq!(issue.level(), IssueLevel::Error);
         assert_eq!(issue.versions.len(), 2);
-        assert_eq!(issue.why(), "React dependencies aren't synced.".to_string());
+        assert_eq!(
+            issue.why(),
+            "Similar React dependencies should use the same version."
+        );
     }
 
     #[test]

--- a/src/rules/unsync_similar_dependencies.rs
+++ b/src/rules/unsync_similar_dependencies.rs
@@ -1,0 +1,127 @@
+use super::Issue;
+use crate::packages::semversion::SemVersion;
+use colored::Colorize;
+use indexmap::IndexMap;
+use std::{borrow::Cow, fmt::Display};
+
+#[derive(Debug, Hash, PartialEq, Eq)]
+pub enum SimilarDependency {
+    NextJS,
+    Turborepo,
+}
+
+impl Display for SimilarDependency {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NextJS => write!(f, "Next.js"),
+            Self::Turborepo => write!(f, "Turborepo"),
+        }
+    }
+}
+
+impl TryFrom<&str> for SimilarDependency {
+    type Error = anyhow::Error;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            // Next.js
+            "next" => Ok(Self::NextJS),
+            "@next/eslint-plugin-next" => Ok(Self::NextJS),
+            "eslint-config-next" => Ok(Self::NextJS),
+            "@next/bundle-analyzer" => Ok(Self::NextJS),
+            "@next/third-parties" => Ok(Self::NextJS),
+            "@next/mdx" => Ok(Self::NextJS),
+            // Turborepo
+            "turbo" => Ok(Self::Turborepo),
+            "turbo-ignore" => Ok(Self::Turborepo),
+            "eslint-config-turbo" => Ok(Self::Turborepo),
+            "eslint-plugin-turbo" => Ok(Self::Turborepo),
+            "@turbo/gen" => Ok(Self::Turborepo),
+            "@turbo/workspaces" => Ok(Self::Turborepo),
+            _ => Err(anyhow::anyhow!("Unknown similar dependency")),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct UnsyncSimilarDependenciesIssue {
+    r#type: SimilarDependency,
+    versions: IndexMap<String, Vec<(String, SemVersion)>>,
+    fixed: bool,
+}
+
+impl UnsyncSimilarDependenciesIssue {
+    pub fn new(
+        r#type: SimilarDependency,
+        versions: IndexMap<String, Vec<(String, SemVersion)>>,
+    ) -> Box<Self> {
+        Box::new(Self {
+            r#type,
+            versions,
+            fixed: false,
+        })
+    }
+}
+
+impl Issue for UnsyncSimilarDependenciesIssue {
+    fn name(&self) -> &str {
+        "unsync-similar-dependencies"
+    }
+
+    fn level(&self) -> super::IssueLevel {
+        match self.fixed {
+            true => super::IssueLevel::Fixed,
+            false => super::IssueLevel::Error,
+        }
+    }
+
+    fn message(&self) -> String {
+        self.versions
+            .iter()
+            .map(|(dependency, versions)| {
+                // let version_pad = " ".repeat(if dependency.len() >= 26 {
+                //     3
+                // } else {
+                //     26 - dependency.len()
+                // });
+                //
+                // format!(
+                //     "  {}{}{}",
+                //     dependency.bright_black(),
+                //     version_pad,
+                //     versions.get(0).unwrap().1
+                // )
+
+                versions
+                    .iter()
+                    .map(|(package, version)| {
+                        let location = format!(
+                            "{} {}",
+                            dependency.white(),
+                            format!("in {}", package).bright_black()
+                        );
+                        let len = format!("{} in {}", dependency, package).len();
+                        let version_pad = " ".repeat(if len >= 50 { 3 } else { 50 - len });
+
+                        format!(
+                            "  {}{}{}",
+                            location,
+                            version_pad,
+                            version.to_string().yellow()
+                        )
+                    })
+                    .collect::<Vec<String>>()
+                    .join("\n")
+            })
+            .collect::<Vec<String>>()
+            .join("\n")
+    }
+
+    fn why(&self) -> Cow<'static, str> {
+        Cow::Owned(format!("Dependencies for {} aren't synced.", self.r#type))
+    }
+
+    fn fix(&mut self, _package_type: &super::PackageType) -> anyhow::Result<()> {
+        Ok(())
+    }
+}


### PR DESCRIPTION
Similar dependencies in a given `package.json` should use the same version. For example, if you use both `react` and `react-dom` dependencies in the same `package.json`, this rule will enforce that they use the same version.