### PR TITLE
feat(action): reuse args from package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ npx sherif@latest
 
 We recommend running Sherif in your CI once [all errors are fixed](#autofix). Run it by **specifying a version instead of latest**. This is useful to prevent regressions (e.g. when adding a library to a package but forgetting to update the version in other packages of the monorepo).
 
+By default, it will search for a `sherif` script in the root `package.json` and try to use the same arguments, so you can avoid repeating yourself. But you can override this behaviour with the `args` param.
+
 <details>
 
 <summary>GitHub Actions example</summary>
@@ -82,7 +84,7 @@ sherif --fix
 
 ### No-install mode
 
-If you don't want Sherif to run your packager manager's `install` command after running autofix, you can use the `--no-install` flag: 
+If you don't want Sherif to run your packager manager's `install` command after running autofix, you can use the `--no-install` flag:
 
 ```bash
 sherif --fix --no-install
@@ -168,4 +170,3 @@ Dependencies should be ordered alphabetically to prevent complex diffs when inst
 ## License
 
 [MIT](./LICENSE)
-

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ npx sherif@latest
 
 We recommend running Sherif in your CI once [all errors are fixed](#autofix). Run it by **specifying a version instead of latest**. This is useful to prevent regressions (e.g. when adding a library to a package but forgetting to update the version in other packages of the monorepo).
 
-By default, it will search for a `sherif` script in the root `package.json` and try to use the same arguments, so you can avoid repeating yourself. But you can override this behaviour with the `args` param.
+When using the GitHub Action, it will search for a `sherif` script in the root `package.json` and use the same arguments automatically to avoid repeating them twice. You can override this behaviour with the `args` parameter.
 
 <details>
 

--- a/action/index.js
+++ b/action/index.js
@@ -32687,19 +32687,12 @@ function getArgsFromPackageJson() {
         try {
             const packageJsonFile = yield fsp.readFile(path.resolve(process.cwd(), 'package.json'));
             const packageJson = JSON.parse(packageJsonFile.toString());
-            if (!('scripts' in packageJson)) {
-                core.info('No scripts found in package.json');
-                return;
-            }
-            if (!('sherif' in packageJson.scripts)) {
-                core.info('No sherif script found in package.json');
-                return;
-            }
-            // Select the args of the sherif script
+            // Extract args from the `sherif` script in package.json, starting after
+            // `sherif ` and ending before the next `&&` or end of line
             const regexResult = /sherif\s([a-zA-Z\s\.-]*)(?=\s&&|$)/g.exec(packageJson.scripts.sherif);
             if (regexResult && regexResult.length > 1) {
                 const args = regexResult[1];
-                core.info(`Found args "${args}" package.json`);
+                core.info(`Using the arguments "${args}" from the root package.json`);
                 return args;
             }
         }

--- a/action/index.ts
+++ b/action/index.ts
@@ -129,23 +129,14 @@ async function getArgsFromPackageJson() {
     );
     const packageJson = JSON.parse(packageJsonFile.toString());
 
-    if (!('scripts' in packageJson)) {
-      core.info('No scripts found in package.json');
-      return;
-    }
-
-    if (!('sherif' in packageJson.scripts)) {
-      core.info('No sherif script found in package.json');
-      return;
-    }
-
-    // Select the args of the sherif script
+    // Extract args from the `sherif` script in package.json, starting after
+    // `sherif ` and ending before the next `&&` or end of line
     const regexResult = /sherif\s([a-zA-Z\s\.-]*)(?=\s&&|$)/g.exec(
       packageJson.scripts.sherif
     );
     if (regexResult && regexResult.length > 1) {
       const args = regexResult[1];
-      core.info(`Found args "${args}" package.json`);
+      core.info(`Using the arguments "${args}" from the root package.json`);
       return args;
     }
   } catch {


### PR DESCRIPTION
If the action doesn't have the `args` param, and the root package.json contains a script called "sherif", pass the arguments of the sherif script to the action to avoid repeating the same args in the root package.json and the action