### PR TITLE
feat: support basic glob matching when ignoring deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ You can ignore this rule for a specific dependency and version or all versions o
 # Ignore only the specific dependency version mismatch
 sherif -i react@17.0.2 -i next@13.2.4
 
-# Ignore all versions mismatch of dependencies that starts with @next/
+# Ignore all versions mismatch of dependencies that start with @next/
 sherif -i @next/*
 
 # Completely ignore all versions mismatch of these dependencies

--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@ You can ignore this rule for a specific dependency and version or all versions o
 # Ignore only the specific dependency version mismatch
 sherif -i react@17.0.2 -i next@13.2.4
 
+# Ignore all versions mismatch of dependencies that starts with @next/
+sherif -i @next/*
+
 # Completely ignore all versions mismatch of these dependencies
 sherif -i react -i next
 ```
@@ -168,4 +171,3 @@ Dependencies should be ordered alphabetically to prevent complex diffs when inst
 ## License
 
 [MIT](./LICENSE)
-

--- a/fixtures/dependencies/docs/package.json
+++ b/fixtures/dependencies/docs/package.json
@@ -1,6 +1,7 @@
 {
   "name": "docs",
   "dependencies": {
+    "@eslint/js": "7.8.9",
     "eslint": "7.8.9",
     "next": "1.2.3",
     "react": "4.5.6"

--- a/fixtures/dependencies/packages/abc/package.json
+++ b/fixtures/dependencies/packages/abc/package.json
@@ -1,6 +1,7 @@
 {
   "name": "abc",
   "dependencies": {
+    "@eslint/js": "9.8.7",
     "next": "4.5.6",
     "react": "1.2.3"
   }

--- a/src/collect.rs
+++ b/src/collect.rs
@@ -320,6 +320,18 @@ pub fn collect_issues(args: &Args, packages_list: PackagesList) -> IssuesList<'_
                 .windows(2)
                 .all(|window| window[0] == window[1])
             && !args.ignore_dependency.contains(&name)
+            && !args.ignore_dependency.iter().any(|dependency| {
+                if dependency.ends_with('*') {
+                    if dependency.starts_with('*') {
+                        return name
+                            .contains(dependency.trim_start_matches('*').trim_end_matches('*'));
+                    }
+                    return name.starts_with(dependency.trim_end_matches('*'));
+                } else if dependency.starts_with('*') {
+                    return name.ends_with(dependency.trim_start_matches('*'));
+                }
+                false
+            })
         {
             filtered_versions.sort_keys();
 
@@ -607,7 +619,7 @@ mod test {
         assert_eq!(packages_list.root_package.get_name(), "dependencies");
 
         let issues = collect_issues(&args, packages_list);
-        assert_eq!(issues.total_len(), 3);
+        assert_eq!(issues.total_len(), 4);
 
         let issues = issues.into_iter().collect::<IndexMap<_, _>>();
 
@@ -623,6 +635,10 @@ mod test {
             issues.get(&PackageType::None).unwrap()[2].name(),
             "multiple-dependency-versions"
         );
+        assert_eq!(
+            issues.get(&PackageType::None).unwrap()[3].name(),
+            "multiple-dependency-versions"
+        );
     }
 
     #[test]
@@ -633,23 +649,19 @@ mod test {
             no_install: false,
             ignore_rule: Vec::new(),
             ignore_package: Vec::new(),
-            ignore_dependency: vec!["next@4.5.6".to_string()],
+            ignore_dependency: vec!["next@4.5.6".to_string(), "*eslint*".to_string()],
         };
 
         let packages_list = collect_packages(&args).unwrap();
         assert_eq!(packages_list.root_package.get_name(), "dependencies");
 
         let issues = collect_issues(&args, packages_list);
-        assert_eq!(issues.total_len(), 2);
+        assert_eq!(issues.total_len(), 1);
 
         let issues = issues.into_iter().collect::<IndexMap<_, _>>();
 
         assert_eq!(
             issues.get(&PackageType::None).unwrap()[0].name(),
-            "multiple-dependency-versions"
-        );
-        assert_eq!(
-            issues.get(&PackageType::None).unwrap()[1].name(),
             "multiple-dependency-versions"
         );
     }


### PR DESCRIPTION
Support this kind of syntax:
```bash
sherif -i "@next/*"
```