### PR TITLE
feat: add `@trpc/*` to similar dependency list

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Similar dependencies in a given `package.json` should use the same version. For 
 
 - `react`, `react-dom`
 - `eslint-config-next`, `@next/eslint-plugin-next`, `@next/font` `@next/bundle-analyzer`, `@next/third-parties`, `@next/mdx`, `next`
+- `@trpc/client`, `@trpc/server`, `@trpc/next`, `@trpc/react-query`
 - `eslint-config-turbo`, `eslint-plugin-turbo`, `@turbo/gen`, `turbo-ignore`, `turbo`
 - `@tanstack/eslint-plugin-query`, `@tanstack/query-async-storage-persister`, `@tanstack/query-broadcast-client-experimental`, `@tanstack/query-core`, `@tanstack/query-devtools`, `@tanstack/query-persist-client-core`, `@tanstack/query-sync-storage-persister`, `@tanstack/react-query`, `@tanstack/react-query-devtools`, `@tanstack/react-query-persist-client`, `@tanstack/react-query-next-experimental`, `@tanstack/solid-query`, `@tanstack/solid-query-devtools`, `@tanstack/solid-query-persist-client`, `@tanstack/svelte-query`, `@tanstack/svelte-query-devtools`, `@tanstack/svelte-query-persist-client`, `@tanstack/vue-query`, `@tanstack/vue-query-devtools`, `@tanstack/angular-query-devtools-experimental`, `@tanstack/angular-query-experimental`
 

--- a/src/rules/unsync_similar_dependencies.rs
+++ b/src/rules/unsync_similar_dependencies.rs
@@ -6,6 +6,7 @@ use std::{borrow::Cow, fmt::Display, hash::Hash};
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone)]
 pub enum SimilarDependency {
+    Trpc,
     React,
     NextJS,
     Turborepo,
@@ -15,6 +16,7 @@ pub enum SimilarDependency {
 impl Display for SimilarDependency {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::Trpc => write!(f, "tRPC"),
             Self::React => write!(f, "React"),
             Self::NextJS => write!(f, "Next.js"),
             Self::Turborepo => write!(f, "Turborepo"),
@@ -28,6 +30,7 @@ impl TryFrom<&str> for SimilarDependency {
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         match value {
+            "@trpc/client" | "@trpc/server" | "@trpc/next" | "@trpc/react-query" => Ok(Self::Trpc),
             "react" | "react-dom" => Ok(Self::React),
             "eslint-config-next"
             | "@next/eslint-plugin-next"


### PR DESCRIPTION
Added tRPC packages to the list of detected similar dependencies that require consistent versioning within a package.json file. This ensures that related tRPC packages—such as @trpc/client, @trpc/server, @trpc/next, and @trpc/react-query—always use the same version, preventing potential compatibility issues as recommended in their documentation.