### PR TITLE
feat: support `bun.lock` for automatic package manager resolution

### DIFF
--- a/src/install.rs
+++ b/src/install.rs
@@ -90,12 +90,20 @@ mod test {
 
         fs::File::create("package-lock.json").unwrap();
         assert_eq!(PackageManager::resolve().unwrap(), PackageManager::Npm);
-
         fs::remove_file("package-lock.json").unwrap();
+
+        fs::File::create("bun.lockb").unwrap();
+        assert_eq!(PackageManager::resolve().unwrap(), PackageManager::Bun);
+        fs::remove_file("bun.lockb").unwrap();
+
+        fs::File::create("bun.lock").unwrap();
+        assert_eq!(PackageManager::resolve().unwrap(), PackageManager::Bun);
+        fs::remove_file("bun.lock").unwrap();
+
         fs::File::create("yarn.lock").unwrap();
         assert_eq!(PackageManager::resolve().unwrap(), PackageManager::Yarn);
-
         fs::remove_file("yarn.lock").unwrap();
+
         assert_eq!(PackageManager::resolve().unwrap(), PackageManager::Pnpm);
     }
 

--- a/src/install.rs
+++ b/src/install.rs
@@ -18,7 +18,7 @@ impl PackageManager {
     pub fn resolve() -> Result<Self> {
         if fs::metadata("package-lock.json").is_ok() {
             return Ok(PackageManager::Npm);
-        } else if fs::metadata("bun.lockb").is_ok() {
+        } else if fs::metadata("bun.lockb").is_ok() || fs::metadata("bun.lock").is_ok() {
             return Ok(PackageManager::Bun);
         } else if fs::metadata("yarn.lock").is_ok() {
             return Ok(PackageManager::Yarn);


### PR DESCRIPTION
Adds support for the new `bun.lock` text format released in Bun 1.2 [https://bun.sh/blog/bun-v1.2#introducing-bun-lock](https://bun.sh/blog/bun-v1.2#introducing-bun-lock)