### PR TITLE
[ci] update ubuntu to 22 again

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,7 +127,7 @@ jobs:
   publish-npm-base:
     name: Publish NPM package
     needs: publish-npm-binaries
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Following https://github.com/QuiiBz/sherif/pull/125, missed the last job that publishes the main package to NPM, so the last job failed (and I had to publish the package manually): https://github.com/QuiiBz/sherif/actions/runs/15763109000/job/44434198657