### PR TITLE
feat: log process spawn errors

### DIFF
--- a/npm/app/index.js
+++ b/npm/app/index.js
@@ -35,6 +35,13 @@ function getExePath() {
 function run() {
   const args = process.argv.slice(2)
   const processResult = spawnSync(getExePath(), args, { stdio: 'inherit' })
+
+  if (processResult.error) {
+    console.error(`Failed to execute sherif: ${processResult.error.message}`)
+    console.error("Please report this issue: https://github.com/QuiiBz/sherif/issues")
+    process.exit(1)
+  }
+
   process.exit(processResult.status ?? 0)
 }
 


### PR DESCRIPTION
Related to https://github.com/QuiiBz/sherif/issues/131

When spawning the process, it might currently fail silently (e.g. with `ENOENT` and exit code 0). In those cases, it appears that Sherif did not report any errors, while it actually did not run at all. If there is an error, print it and exit with code 1