### PR TITLE
feat: add `--version` flag to cli

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -21,6 +21,7 @@ impl Display for AutofixSelect {
 }
 
 #[derive(Debug, Parser, Deserialize, Clone)]
+#[command(version)]
 pub struct Args {
     /// Path to the monorepo root.
     #[arg(default_value = ".")]


### PR DESCRIPTION
I want to add sherif to [mise versions](https://mise-versions.jdx.dev/) [registry](https://github.com/jdx/mise/tree/21bbee1149d4d4311704c602506dacc8a950aa04/registry). It's usually checks for the version to test.