### PR TITLE
fix(non-existant-packages): handle object form workspaces in autofix

### DIFF
--- a/src/rules/non_existant_packages.rs
+++ b/src/rules/non_existant_packages.rs
@@ -27,12 +27,14 @@ impl NonExistantPackagesIssue {
             .packages_list
             .iter()
             .map(|package| match self.paths.contains(package) {
-                true => format!(
-                    "  {}  - '{}'   {}",
-                    "-".red(),
-                    package.white(),
-                    "← but this one doesn't match any package".red(),
-                ),
+                true => {
+                    format!(
+                        "  {}  - '{}'   {}",
+                        "-".red(),
+                        package.white(),
+                        "← but this one doesn't match any package".red(),
+                    )
+                }
                 false => format!("  │  - '{}'", package),
             })
             .collect::<Vec<String>>()
@@ -131,26 +133,51 @@ impl Issue for NonExistantPackagesIssue {
                     let (mut value, indent, lineending) =
                         json::deserialize::<serde_json::Value>(&value)?;
 
-                    value
-                        .get_mut("workspaces")
-                        .unwrap()
-                        .as_array_mut()
-                        .unwrap()
-                        .retain(|package| {
-                            let package = package.as_str().unwrap().to_string();
+                    let workspaces = value.get_mut("workspaces").unwrap();
 
-                            !self.paths.contains(&package)
-                        });
+                    // Leave the issue unfixed (so it is still reported) when the
+                    // `workspaces` field has an unexpected shape we can't edit.
+                    if retain_existing_workspace_paths(workspaces, &self.paths) {
+                        let value = json::serialize(&value, indent, lineending)?;
+                        fs::write(path, value)?;
 
-                    let value = json::serialize(&value, indent, lineending)?;
-                    fs::write(path, value)?;
-
-                    self.fixed = true;
+                        self.fixed = true;
+                    }
                 }
             }
         }
 
         Ok(())
+    }
+}
+
+/// Removes the given `paths` from a root `package.json` `workspaces` field.
+///
+/// The field can be either an array (`["packages/*"]`) or an object holding a
+/// `packages` array (Yarn/Bun: `{ "packages": ["packages/*"] }`).
+///
+/// Returns `true` when the field had a known shape and was edited, and `false`
+/// when the shape is unrecognized and was left untouched (so the caller can
+/// keep reporting the issue instead of silently claiming a fix).
+fn retain_existing_workspace_paths(workspaces: &mut serde_json::Value, paths: &[String]) -> bool {
+    let workspace_paths = match workspaces {
+        serde_json::Value::Array(workspace_paths) => Some(workspace_paths),
+        serde_json::Value::Object(object) => object
+            .get_mut("packages")
+            .and_then(serde_json::Value::as_array_mut),
+        _ => None,
+    };
+
+    match workspace_paths {
+        Some(workspace_paths) => {
+            workspace_paths.retain(|package| match package.as_str() {
+                Some(package) => !paths.contains(&package.to_string()),
+                None => true,
+            });
+
+            true
+        }
+        None => false,
     }
 }
 
@@ -211,5 +238,47 @@ mod test {
 
         colored::control::set_override(false);
         insta::assert_snapshot!(issue.message());
+    }
+
+    #[test]
+    fn retain_paths_array_workspaces() {
+        let mut workspaces = serde_json::json!(["apps/*", "empty/*", "docs"]);
+
+        let edited =
+            retain_existing_workspace_paths(&mut workspaces, &["empty/*".into(), "docs".into()]);
+
+        assert!(edited);
+        assert_eq!(workspaces, serde_json::json!(["apps/*"]));
+    }
+
+    #[test]
+    fn retain_paths_object_workspaces() {
+        // Yarn/Bun object form: `{ "packages": [...] }`. Previously panicked.
+        let mut workspaces = serde_json::json!({
+            "packages": ["apps/*", "empty/*", "docs"],
+            "catalog": { "react": "^19.0.0" },
+        });
+
+        let edited =
+            retain_existing_workspace_paths(&mut workspaces, &["empty/*".into(), "docs".into()]);
+
+        assert!(edited);
+        assert_eq!(
+            workspaces,
+            serde_json::json!({
+                "packages": ["apps/*"],
+                "catalog": { "react": "^19.0.0" },
+            })
+        );
+    }
+
+    #[test]
+    fn retain_paths_unknown_shape_is_noop() {
+        let mut workspaces = serde_json::json!("packages/*");
+
+        let edited = retain_existing_workspace_paths(&mut workspaces, &["packages/*".into()]);
+
+        assert!(!edited);
+        assert_eq!(workspaces, serde_json::json!("packages/*"));
     }
 }


### PR DESCRIPTION
Running sherif -f on a repo whose root package.json declares workspaces
as an object panics instead of applying the fix. The object form is what
Yarn and Bun use, a nested packages array plus an optional catalog:

    "workspaces": {
      "packages": ["apps/*", "packages/*"],
      "catalog": { "react": "^19.0.0" }
    }

With a workspace path that matches no package, sherif -f crashes:

    thread 'main' panicked at src/rules/non_existant_packages.rs:138:26:
    called `Option::unwrap()` on a `None` value

Cause

The autofix for non-existant-packages assumed workspaces was always a
JSON array and called as_array_mut().unwrap() on it. For the object form
that returns None, so the unwrap panics. The read path already supports
both shapes through the Workspaces enum (Default and Yarn), only the fix
path did not.

Fix

Extract the path filtering into retain_existing_workspace_paths, which
handles both shapes: a plain array, or an object with a packages array.
It returns whether the field had a known shape and was edited. When the
shape is unrecognized the file is left untouched and the issue stays
unfixed, so sherif still reports it instead of silently writing the file
back and claiming a fix it did not make.

Tests

Adds three unit tests for the helper: the array form, the object form
that used to panic, and an unrelated shape that should be a no op. Each
asserts both the resulting value and the return flag.

How to reproduce before the fix

1. Create a package.json with the object form workspaces above and a
   path that matches no package, for example packages/wip/*.
2. Add one real package so the workspace is otherwise valid.
3. Run sherif -f. It panics with the unwrap error above. With this
   change it removes the dead path and writes the file back, keeping
   the object form and the catalog intact.
