### PR TITLE
feat: support `devEngines` for `root-package-manager-field` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ The root `package.json` is private, so making a distinction between `dependencie
 
 #### `root-package-manager-field` ❌
 
-The root `package.json` should specify the package manager and version to use. Useful for tools like corepack.
+The root `package.json` should specify the package manager and version to use, either via the `packageManager` field or the `devEngines.packageManager` field. Useful for tools like corepack.
 
 #### `root-package-private-field` ❌
 

--- a/fixtures/dev-engines-array/package.json
+++ b/fixtures/dev-engines-array/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "dev-engines-array",
+  "workspaces": [],
+  "private": true,
+  "devEngines": {
+    "packageManager": [
+      { "name": "bun", "version": ">= 1.0.0", "onFail": "ignore" },
+      { "name": "pnpm", "version": "9.0.0", "onFail": "download" }
+    ]
+  }
+}

--- a/fixtures/dev-engines-no-package-manager/package.json
+++ b/fixtures/dev-engines-no-package-manager/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "dev-engines-no-package-manager",
+  "workspaces": [],
+  "private": true,
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "version": ">= 20.0.0"
+    }
+  }
+}

--- a/fixtures/dev-engines/package.json
+++ b/fixtures/dev-engines/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "dev-engines",
+  "workspaces": [],
+  "private": true,
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "version": "9.0.0"
+    }
+  }
+}

--- a/src/collect.rs
+++ b/src/collect.rs
@@ -615,6 +615,78 @@ mod test {
     }
 
     #[test]
+    fn collect_root_dev_engines() {
+        let args = Args {
+            path: "fixtures/dev-engines".into(),
+            fix: false,
+            select: None,
+            no_install: true,
+            fail_on_warnings: false,
+            ignore_rule: Vec::new(),
+            ignore_package: Vec::new(),
+            ignore_dependency: Vec::new(),
+        };
+
+        let packages_list = collect_packages(&args.path).unwrap();
+        assert_eq!(packages_list.root_package.get_name(), "dev-engines");
+
+        let config = args.into();
+        let issues = collect_issues(&config, packages_list);
+        assert_eq!(issues.total_len(), 0);
+    }
+
+    #[test]
+    fn collect_root_dev_engines_array() {
+        let args = Args {
+            path: "fixtures/dev-engines-array".into(),
+            fix: false,
+            select: None,
+            no_install: true,
+            fail_on_warnings: false,
+            ignore_rule: Vec::new(),
+            ignore_package: Vec::new(),
+            ignore_dependency: Vec::new(),
+        };
+
+        let packages_list = collect_packages(&args.path).unwrap();
+        assert_eq!(packages_list.root_package.get_name(), "dev-engines-array");
+
+        let config = args.into();
+        let issues = collect_issues(&config, packages_list);
+        assert_eq!(issues.total_len(), 0);
+    }
+
+    #[test]
+    fn collect_root_dev_engines_without_package_manager() {
+        let args = Args {
+            path: "fixtures/dev-engines-no-package-manager".into(),
+            fix: false,
+            select: None,
+            no_install: true,
+            fail_on_warnings: false,
+            ignore_rule: Vec::new(),
+            ignore_package: Vec::new(),
+            ignore_dependency: Vec::new(),
+        };
+
+        let packages_list = collect_packages(&args.path).unwrap();
+        assert_eq!(
+            packages_list.root_package.get_name(),
+            "dev-engines-no-package-manager"
+        );
+
+        let config = args.into();
+        let issues = collect_issues(&config, packages_list);
+        assert_eq!(issues.total_len(), 1);
+
+        let issues = issues.into_iter().collect::<IndexMap<_, _>>();
+        assert_eq!(
+            issues.get(&PackageType::Root).unwrap()[0].name(),
+            "root-package-manager-field"
+        );
+    }
+
+    #[test]
     fn collect_dependencies() {
         let args = Args {
             path: "fixtures/dependencies".into(),

--- a/src/packages/mod.rs
+++ b/src/packages/mod.rs
@@ -77,12 +77,33 @@ impl Config {
 }
 
 #[derive(Deserialize, Debug)]
+struct DevEngineDependency {
+    #[allow(dead_code)]
+    name: String,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(untagged)]
+#[allow(dead_code)]
+enum DevEngineField {
+    Single(DevEngineDependency),
+    Multiple(Vec<DevEngineDependency>),
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct DevEngines {
+    package_manager: Option<DevEngineField>,
+}
+
+#[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 struct PackageInner {
     name: Option<String>,
     private: Option<bool>,
     workspaces: Option<Workspaces>,
     package_manager: Option<String>,
+    dev_engines: Option<DevEngines>,
     dependencies: Option<IndexMap<String, String>>,
     dev_dependencies: Option<IndexMap<String, String>>,
     peer_dependencies: Option<IndexMap<String, String>>,
@@ -130,6 +151,17 @@ impl Package {
 
     pub fn is_private(&self) -> bool {
         self.inner.private.unwrap_or(false)
+    }
+
+    pub fn has_package_manager(&self) -> bool {
+        if self.inner.package_manager.is_some() {
+            return true;
+        }
+
+        match &self.inner.dev_engines {
+            Some(dev_engines) => dev_engines.package_manager.is_some(),
+            None => false,
+        }
     }
 
     fn check_deps(

--- a/src/packages/root.rs
+++ b/src/packages/root.rs
@@ -48,9 +48,9 @@ impl RootPackage {
     }
 
     pub fn check_package_manager(&self) -> Option<BoxIssue> {
-        match self.0.inner.package_manager.is_none() {
-            true => Some(RootPackageManagerFieldIssue::new()),
-            false => None,
+        match self.0.has_package_manager() {
+            true => None,
+            false => Some(RootPackageManagerFieldIssue::new()),
         }
     }
 

--- a/src/rules/root_package_manager_field.rs
+++ b/src/rules/root_package_manager_field.rs
@@ -34,7 +34,7 @@ impl Issue for RootPackageManagerFieldIssue {
     }
 
     fn why(&self) -> Cow<'static, str> {
-        Cow::Borrowed("The root package.json should specify the package manager and version to use. Useful for tools like corepack.")
+        Cow::Borrowed("The root package.json should specify the package manager and version to use, via the `packageManager` or `devEngines.packageManager` field. Useful for tools like corepack.")
     }
 }
 
@@ -53,7 +53,7 @@ mod test {
         insta::assert_snapshot!(issue.message());
         assert_eq!(
             issue.why(),
-            "The root package.json should specify the package manager and version to use. Useful for tools like corepack."
+            "The root package.json should specify the package manager and version to use, via the `packageManager` or `devEngines.packageManager` field. Useful for tools like corepack."
         );
     }
 }


### PR DESCRIPTION
This PR adds support of the npm [`devEngines`](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#devengines) configuration. 
It's a successor of the `packageManager` field.